### PR TITLE
Add Python MessageWriter for OMG IDL serialization

### DIFF
--- a/python_omgidl/omgidl_serialization/__init__.py
+++ b/python_omgidl/omgidl_serialization/__init__.py
@@ -1,0 +1,3 @@
+from .message_writer import MessageWriter
+
+__all__ = ["MessageWriter"]

--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import struct
+from typing import List, Dict, Any, Optional
+
+from omgidl_parser.parse import Struct, Field, Module
+
+
+PRIMITIVE_SIZES: Dict[str, int] = {
+    "bool": 1,
+    "int8": 1,
+    "uint8": 1,
+    "int16": 2,
+    "uint16": 2,
+    "int32": 4,
+    "uint32": 4,
+    "int64": 8,
+    "uint64": 8,
+    "float32": 4,
+    "float64": 8,
+}
+
+PRIMITIVE_FORMATS: Dict[str, str] = {
+    "bool": "b",
+    "int8": "b",
+    "uint8": "B",
+    "int16": "h",
+    "uint16": "H",
+    "int32": "i",
+    "uint32": "I",
+    "int64": "q",
+    "uint64": "Q",
+    "float32": "f",
+    "float64": "d",
+}
+
+
+class MessageWriter:
+    """Serialize Python dictionaries to CDR-encoded bytes.
+
+    This is a minimal Python port of the TypeScript MessageWriter. It supports
+    primitive fields and fixed-length arrays as produced by the simplified
+    ``parse_idl`` parser.
+    """
+
+    def __init__(self, root_definition_name: str, definitions: List[Struct | Module]) -> None:
+        root = _find_struct(definitions, root_definition_name)
+        if root is None:
+            raise ValueError(f'Root definition name "{root_definition_name}" not found in schema definitions.')
+        self.root = root
+
+    # public API -------------------------------------------------------------
+    def calculate_byte_size(self, message: Dict[str, Any]) -> int:
+        return self._byte_size(self.root.fields, message, 4)
+
+    def write_message(self, message: Dict[str, Any]) -> bytes:
+        size = self.calculate_byte_size(message)
+        buffer = bytearray(size)
+        # CDR header for little-endian PL_CDR2
+        buffer[0:4] = b"\x00\x01\x00\x00"
+        self._write(self.root.fields, message, buffer, 4)
+        return bytes(buffer)
+
+    # internal helpers ------------------------------------------------------
+    def _byte_size(self, definition: List[Field], message: Dict[str, Any], offset: int) -> int:
+        msg = message or {}
+        new_offset = offset
+        for field in definition:
+            value = msg.get(field.name)
+            new_offset = self._field_size(field, value, new_offset)
+        return new_offset
+
+    def _field_size(self, field: Field, value: Any, offset: int) -> int:
+        t = field.type
+        if field.array_length is not None:
+            if t == "string":
+                arr = value if isinstance(value, (list, tuple)) else []
+                for i in range(field.array_length):
+                    s = arr[i] if i < len(arr) and isinstance(arr[i], str) else ""
+                    offset += _padding(offset, 4)
+                    offset += 4 + len(s.encode("utf-8")) + 1
+            else:
+                size = _primitive_size(t)
+                offset += _padding(offset, size)
+                offset += size * field.array_length
+        else:
+            if t == "string":
+                s = value if isinstance(value, str) else ""
+                offset += _padding(offset, 4)
+                offset += 4 + len(s.encode("utf-8")) + 1
+            else:
+                size = _primitive_size(t)
+                offset += _padding(offset, size)
+                offset += size
+        return offset
+
+    def _write(self, definition: List[Field], message: Dict[str, Any], buffer: bytearray, offset: int) -> int:
+        msg = message or {}
+        new_offset = offset
+        for field in definition:
+            value = msg.get(field.name)
+            new_offset = self._write_field(field, value, buffer, new_offset)
+        return new_offset
+
+    def _write_field(self, field: Field, value: Any, buffer: bytearray, offset: int) -> int:
+        t = field.type
+        if field.array_length is not None:
+            if t == "string":
+                arr = value if isinstance(value, (list, tuple)) else []
+                for i in range(field.array_length):
+                    s = arr[i] if i < len(arr) and isinstance(arr[i], str) else ""
+                    offset += _padding(offset, 4)
+                    encoded = s.encode("utf-8")
+                    length = len(encoded) + 1
+                    struct.pack_into("<I", buffer, offset, length)
+                    offset += 4
+                    buffer[offset:offset+len(encoded)] = encoded
+                    offset += len(encoded)
+                    buffer[offset] = 0
+                    offset += 1
+            else:
+                size = _primitive_size(t)
+                fmt = "<" + PRIMITIVE_FORMATS[t]
+                arr = value if isinstance(value, (list, tuple)) else []
+                offset += _padding(offset, size)
+                for i in range(field.array_length):
+                    v = arr[i] if i < len(arr) else 0
+                    struct.pack_into(fmt, buffer, offset, v)
+                    offset += size
+        else:
+            if t == "string":
+                s = value if isinstance(value, str) else ""
+                offset += _padding(offset, 4)
+                encoded = s.encode("utf-8")
+                length = len(encoded) + 1
+                struct.pack_into("<I", buffer, offset, length)
+                offset += 4
+                buffer[offset:offset+len(encoded)] = encoded
+                offset += len(encoded)
+                buffer[offset] = 0
+                offset += 1
+            else:
+                size = _primitive_size(t)
+                fmt = "<" + PRIMITIVE_FORMATS[t]
+                offset += _padding(offset, size)
+                v = value if value is not None else 0
+                struct.pack_into(fmt, buffer, offset, v)
+                offset += size
+        return offset
+
+
+def _padding(offset: int, byte_width: int) -> int:
+    alignment = (offset - 4) % byte_width
+    return 0 if alignment == 0 else byte_width - alignment
+
+
+def _primitive_size(t: str) -> int:
+    size = PRIMITIVE_SIZES.get(t)
+    if size is None:
+        raise ValueError(f"Unrecognized primitive type {t}")
+    return size
+
+
+def _find_struct(defs: List[Struct | Module], name: str) -> Optional[Struct]:
+    for d in defs:
+        if isinstance(d, Struct) and d.name == name:
+            return d
+        if isinstance(d, Module):
+            found = _find_struct(d.definitions, name)
+            if found is not None:
+                return found
+    return None

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -1,0 +1,53 @@
+import unittest
+
+from omgidl_parser.parse import parse_idl
+from omgidl_serialization import MessageWriter
+
+
+class TestMessageWriter(unittest.TestCase):
+    def test_primitive_fields(self) -> None:
+        schema = """
+        struct A {
+            int32 num;
+            uint8 flag;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg = {"num": 5, "flag": 7}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 7])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+    def test_uint8_array(self) -> None:
+        schema = """
+        struct A {
+            uint8 data[4];
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg = {"data": [1, 2, 3, 4]}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 1, 2, 3, 4])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+    def test_string_field(self) -> None:
+        schema = """
+        struct A {
+            string name;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg = {"name": "hi"}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 3, 0, 0, 0, 104, 105, 0])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `omgidl_serialization` package with `MessageWriter` to encode primitives and arrays in CDR format
- cover basic serialization paths with unit tests

## Testing
- `PYTHONPATH=python_omgidl pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688efc6476848330b4843259908a4801