### PR TITLE
feat(python): support nested structs and sequences

### DIFF
--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -1,6 +1,6 @@
 import unittest
 
-from omgidl_parser.parse import parse_idl
+from omgidl_parser.parse import parse_idl, Struct, Field
 from omgidl_serialization import MessageWriter
 
 
@@ -45,6 +45,47 @@ class TestMessageWriter(unittest.TestCase):
         msg = {"name": "hi"}
         written = writer.write_message(msg)
         expected = bytes([0, 1, 0, 0, 3, 0, 0, 0, 104, 105, 0])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+    def test_nested_struct(self) -> None:
+        inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
+        outer = Struct(name="Outer", fields=[Field(name="inner", type="Inner")])
+        defs = [inner, outer]
+        writer = MessageWriter("Outer", defs)
+        msg = {"inner": {"num": 5}}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+    def test_variable_length_sequence(self) -> None:
+        defs = [Struct(name="A", fields=[Field(name="data", type="int32")])]
+        writer = MessageWriter("A", defs)
+        msg = {"data": [3, 7]}
+        written = writer.write_message(msg)
+        expected = bytes([
+            0, 1, 0, 0,
+            2, 0, 0, 0,
+            3, 0, 0, 0,
+            7, 0, 0, 0,
+        ])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
+    def test_sequence_of_structs(self) -> None:
+        inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
+        outer = Struct(name="Outer", fields=[Field(name="inners", type="Inner")])
+        defs = [inner, outer]
+        writer = MessageWriter("Outer", defs)
+        msg = {"inners": [{"num": 1}, {"num": 2}]}
+        written = writer.write_message(msg)
+        expected = bytes([
+            0, 1, 0, 0,
+            2, 0, 0, 0,
+            1, 0, 0, 0,
+            2, 0, 0, 0,
+        ])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 


### PR DESCRIPTION
## Summary
- allow MessageWriter to serialize nested struct fields
- support variable-length arrays with sequence length prefix
- add tests for nested structs and sequences

## Testing
- `PYTHONPATH=python_omgidl pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f02782474833088519bc8d2acc3a2