### PR TITLE
Add sequence support to Python parser and serializer

### DIFF
--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -39,8 +39,8 @@ class MessageWriter:
     """Serialize Python dictionaries to CDR-encoded bytes.
 
     This is a minimal Python port of the TypeScript MessageWriter. It supports
-    primitive fields and fixed-length arrays as produced by the simplified
-    ``parse_idl`` parser.
+    primitive fields, fixed-length arrays, and variable-length sequences as
+    produced by the simplified ``parse_idl`` parser.
     """
 
     def __init__(self, root_definition_name: str, definitions: List[Struct | Module]) -> None:
@@ -97,9 +97,9 @@ class MessageWriter:
                     offset = self._byte_size(struct_def.fields, msg, offset)
         else:
             # Single field or dynamic sequence
-            if isinstance(value, (list, tuple)):
+            if field.is_sequence or isinstance(value, (list, tuple)):
                 # Variable-length sequence
-                arr = value
+                arr = value if isinstance(value, (list, tuple)) else []
                 length = len(arr)
                 offset += _padding(offset, 4)
                 offset += 4
@@ -179,9 +179,9 @@ class MessageWriter:
                     msg = arr[i] if i < len(arr) and isinstance(arr[i], dict) else {}
                     offset = self._write(struct_def.fields, msg, buffer, offset)
         else:
-            if isinstance(value, (list, tuple)):
+            if field.is_sequence or isinstance(value, (list, tuple)):
                 # Variable-length sequence
-                arr = value
+                arr = value if isinstance(value, (list, tuple)) else []
                 length = len(arr)
                 offset += _padding(offset, 4)
                 struct.pack_into("<I", buffer, offset, length)

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -86,7 +86,7 @@ def _convert_field(field: IDLField) -> MessageDefinitionField:
     return MessageDefinitionField(
         type=field.type,
         name=field.name,
-        isArray=field.array_length is not None,
+        isArray=field.array_length is not None or field.is_sequence,
         arrayLength=field.array_length,
     )
 

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -25,6 +25,18 @@ class TestParseIDL(unittest.TestCase):
             Module(name="outer", definitions=[Struct(name="B", fields=[Field(name="val", type="uint8", array_length=None)])])
         ])
 
+    def test_fixed_array_field(self):
+        schema = """
+        struct A {
+            int32 nums[3];
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [Struct(name="A", fields=[Field(name="nums", type="int32", array_length=3)])],
+        )
+
     def test_constant_in_module(self):
         schema = """
         module outer {
@@ -35,6 +47,25 @@ class TestParseIDL(unittest.TestCase):
         self.assertEqual(result, [
             Module(name="outer", definitions=[Constant(name="A", type="int16", value=-1)])
         ])
+
+    def test_sequence_field(self):
+        schema = """
+        struct A {
+            sequence<int32> nums;
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Struct(
+                    name="A",
+                    fields=[
+                        Field(name="nums", type="int32", array_length=None, is_sequence=True)
+                    ],
+                )
+            ],
+        )
 
     def test_enum(self):
         schema = """

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -71,6 +71,29 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_sequence_field(self):
+        schema = """
+        module pkg {
+          module msg {
+            struct Seq {
+              sequence<int32> data;
+            };
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="pkg/msg/Seq",
+                    definitions=[
+                        MessageDefinitionField(type="int32", name="data", isArray=True)
+                    ],
+                )
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -60,7 +60,7 @@ class TestMessageWriter(unittest.TestCase):
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
     def test_variable_length_sequence(self) -> None:
-        defs = [Struct(name="A", fields=[Field(name="data", type="int32")])]
+        defs = [Struct(name="A", fields=[Field(name="data", type="int32", is_sequence=True)])]
         writer = MessageWriter("A", defs)
         msg = {"data": [3, 7]}
         written = writer.write_message(msg)
@@ -75,7 +75,7 @@ class TestMessageWriter(unittest.TestCase):
 
     def test_sequence_of_structs(self) -> None:
         inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
-        outer = Struct(name="Outer", fields=[Field(name="inners", type="Inner")])
+        outer = Struct(name="Outer", fields=[Field(name="inners", type="Inner", is_sequence=True)])
         defs = [inner, outer]
         writer = MessageWriter("Outer", defs)
         msg = {"inners": [{"num": 1}, {"num": 2}]}


### PR DESCRIPTION
## Summary
- parse `sequence<T>` syntax and track sequence fields
- handle sequences in `MessageWriter`
- expose sequences as arrays in ROS2 message definitions
- add tests for sequences and fixed-length arrays

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0ad16a788330b3b8a763945f5be9