### PR TITLE
Add bounded sequence support and enforcement

### DIFF
--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -101,6 +101,10 @@ class MessageWriter:
                 # Variable-length sequence
                 arr = value if isinstance(value, (list, tuple)) else []
                 length = len(arr)
+                if field.sequence_bound is not None and length > field.sequence_bound:
+                    raise ValueError(
+                        f"Field '{field.name}' sequence length {length} exceeds bound {field.sequence_bound}"
+                    )
                 offset += _padding(offset, 4)
                 offset += 4
                 if t == "string":
@@ -183,6 +187,10 @@ class MessageWriter:
                 # Variable-length sequence
                 arr = value if isinstance(value, (list, tuple)) else []
                 length = len(arr)
+                if field.sequence_bound is not None and length > field.sequence_bound:
+                    raise ValueError(
+                        f"Field '{field.name}' sequence length {length} exceeds bound {field.sequence_bound}"
+                    )
                 offset += _padding(offset, 4)
                 struct.pack_into("<I", buffer, offset, length)
                 offset += 4

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -88,6 +88,7 @@ def _convert_field(field: IDLField) -> MessageDefinitionField:
         name=field.name,
         isArray=field.array_length is not None or field.is_sequence,
         arrayLength=field.array_length,
+        arrayUpperBound=field.sequence_bound if field.is_sequence else None,
     )
 
 

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -67,6 +67,31 @@ class TestParseIDL(unittest.TestCase):
             ],
         )
 
+    def test_bounded_sequence_field(self):
+        schema = """
+        struct A {
+            sequence<int32, 5> nums;
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Struct(
+                    name="A",
+                    fields=[
+                        Field(
+                            name="nums",
+                            type="int32",
+                            array_length=None,
+                            is_sequence=True,
+                            sequence_bound=5,
+                        )
+                    ],
+                )
+            ],
+        )
+
     def test_enum(self):
         schema = """
         enum COLORS {

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -94,6 +94,34 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_bounded_sequence_field(self):
+        schema = """
+        module pkg {
+          module msg {
+            struct Seq {
+              sequence<int32, 7> data;
+            };
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="pkg/msg/Seq",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="int32",
+                            name="data",
+                            isArray=True,
+                            arrayUpperBound=7,
+                        )
+                    ],
+                )
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Track optional sequence bounds in IDL parsing and propagation
- Surface sequence bounds in ros2idl message definitions
- Enforce bounded sequence sizes during serialization and cover with tests

## Testing
- `PYTHONPATH=python_omgidl pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f155474848330ae9b27c0248c7c01