### PR TITLE
Add MessageReader and round-trip tests for Python serialization

### DIFF
--- a/python_omgidl/omgidl_serialization/__init__.py
+++ b/python_omgidl/omgidl_serialization/__init__.py
@@ -1,3 +1,4 @@
 from .message_writer import MessageWriter
+from .message_reader import MessageReader
 
-__all__ = ["MessageWriter"]
+__all__ = ["MessageWriter", "MessageReader"]

--- a/python_omgidl/omgidl_serialization/message_reader.py
+++ b/python_omgidl/omgidl_serialization/message_reader.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import struct
+from typing import Any, Dict, List, Tuple
+
+from omgidl_parser.parse import Struct, Field, Module
+
+from .message_writer import (
+    PRIMITIVE_FORMATS,
+    PRIMITIVE_SIZES,
+    _find_struct,
+    _padding,
+    _primitive_size,
+)
+
+
+class MessageReader:
+    """Deserialize CDR-encoded bytes into Python dictionaries.
+
+    This is a minimal Python port of the TypeScript MessageReader. It supports
+    primitive fields, fixed-length arrays, and variable-length sequences as
+    produced by the simplified ``parse_idl`` parser.
+    """
+
+    def __init__(self, root_definition_name: str, definitions: List[Struct | Module]) -> None:
+        root = _find_struct(definitions, root_definition_name)
+        if root is None:
+            raise ValueError(
+                f'Root definition name "{root_definition_name}" not found in schema definitions.'
+            )
+        self.root = root
+        self.definitions = definitions
+
+    # public API -------------------------------------------------------------
+    def read_message(self, buffer: bytes | bytearray | memoryview) -> Dict[str, Any]:
+        view = buffer if isinstance(buffer, memoryview) else memoryview(buffer)
+        # skip CDR header for little-endian PL_CDR2
+        offset = 4
+        msg, _ = self._read(self.root.fields, view, offset)
+        return msg
+
+    # internal helpers ------------------------------------------------------
+    def _read(self, definition: List[Field], view: memoryview, offset: int) -> Tuple[Dict[str, Any], int]:
+        msg: Dict[str, Any] = {}
+        new_offset = offset
+        for field in definition:
+            value, new_offset = self._read_field(field, view, new_offset)
+            msg[field.name] = value
+        return msg, new_offset
+
+    def _read_field(self, field: Field, view: memoryview, offset: int) -> Tuple[Any, int]:
+        t = field.type
+        if field.array_length is not None:
+            # Fixed-length array
+            if t == "string":
+                arr: List[str] = []
+                for _ in range(field.array_length):
+                    offset += _padding(offset, 4)
+                    length = struct.unpack_from("<I", view, offset)[0]
+                    offset += 4
+                    data = bytes(view[offset : offset + length - 1])
+                    offset += length
+                    arr.append(data.decode("utf-8"))
+                return arr, offset
+            elif t in PRIMITIVE_SIZES:
+                size = _primitive_size(t)
+                fmt = "<" + PRIMITIVE_FORMATS[t]
+                arr: List[Any] = []
+                offset += _padding(offset, size)
+                for _ in range(field.array_length):
+                    val = struct.unpack_from(fmt, view, offset)[0]
+                    offset += size
+                    if t == "bool":
+                        val = bool(val)
+                    arr.append(val)
+                return arr, offset
+            else:
+                struct_def = _find_struct(self.definitions, t)
+                if struct_def is None:
+                    raise ValueError(f"Unrecognized struct type {t}")
+                arr: List[Any] = []
+                for _ in range(field.array_length):
+                    msg, offset = self._read(struct_def.fields, view, offset)
+                    arr.append(msg)
+                return arr, offset
+        else:
+            if field.is_sequence:
+                # Variable-length sequence
+                offset += _padding(offset, 4)
+                length = struct.unpack_from("<I", view, offset)[0]
+                offset += 4
+                arr: List[Any] = []
+                if t == "string":
+                    for _ in range(length):
+                        offset += _padding(offset, 4)
+                        slen = struct.unpack_from("<I", view, offset)[0]
+                        offset += 4
+                        data = bytes(view[offset : offset + slen - 1])
+                        offset += slen
+                        arr.append(data.decode("utf-8"))
+                elif t in PRIMITIVE_SIZES:
+                    size = _primitive_size(t)
+                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    offset += _padding(offset, size)
+                    for _ in range(length):
+                        val = struct.unpack_from(fmt, view, offset)[0]
+                        offset += size
+                        if t == "bool":
+                            val = bool(val)
+                        arr.append(val)
+                else:
+                    struct_def = _find_struct(self.definitions, t)
+                    if struct_def is None:
+                        raise ValueError(f"Unrecognized struct type {t}")
+                    for _ in range(length):
+                        msg, offset = self._read(struct_def.fields, view, offset)
+                        arr.append(msg)
+                return arr, offset
+            else:
+                if t == "string":
+                    offset += _padding(offset, 4)
+                    length = struct.unpack_from("<I", view, offset)[0]
+                    offset += 4
+                    data = bytes(view[offset : offset + length - 1])
+                    offset += length
+                    return data.decode("utf-8"), offset
+                elif t in PRIMITIVE_SIZES:
+                    size = _primitive_size(t)
+                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    offset += _padding(offset, size)
+                    val = struct.unpack_from(fmt, view, offset)[0]
+                    offset += size
+                    if t == "bool":
+                        val = bool(val)
+                    return val, offset
+                else:
+                    struct_def = _find_struct(self.definitions, t)
+                    if struct_def is None:
+                        raise ValueError(f"Unrecognized struct type {t}")
+                    msg, offset = self._read(struct_def.fields, view, offset)
+                    return msg, offset

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -1,0 +1,84 @@
+import unittest
+
+from omgidl_parser.parse import parse_idl, Struct, Field
+from omgidl_serialization import MessageWriter, MessageReader
+
+
+class TestMessageReader(unittest.TestCase):
+    def test_roundtrip_primitive_fields(self) -> None:
+        schema = """
+        struct A {
+            int32 num;
+            uint8 flag;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"num": 5, "flag": 7}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_uint8_array(self) -> None:
+        schema = """
+        struct A {
+            uint8 data[4];
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"data": [1, 2, 3, 4]}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_string_field(self) -> None:
+        schema = """
+        struct A {
+            string name;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"name": "hi"}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_nested_struct(self) -> None:
+        inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
+        outer = Struct(name="Outer", fields=[Field(name="inner", type="Inner")])
+        defs = [inner, outer]
+        writer = MessageWriter("Outer", defs)
+        reader = MessageReader("Outer", defs)
+        msg = {"inner": {"num": 5}}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_variable_length_sequence(self) -> None:
+        defs = [Struct(name="A", fields=[Field(name="data", type="int32", is_sequence=True)])]
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"data": [3, 7]}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_sequence_of_structs(self) -> None:
+        inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
+        outer = Struct(name="Outer", fields=[Field(name="inners", type="Inner", is_sequence=True)])
+        defs = [inner, outer]
+        writer = MessageWriter("Outer", defs)
+        reader = MessageReader("Outer", defs)
+        msg = {"inners": [{"num": 1}, {"num": 2}]}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- port MessageReader from TypeScript for decoding CDR-encoded messages
- export MessageReader in serialization package
- add round-trip tests using MessageWriter and MessageReader

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests`


------
https://chatgpt.com/codex/tasks/task_e_688f156e519c83309e670027e25399fe