### PR TITLE
Add typedef and union parsing and serialization

### DIFF
--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -1,3 +1,12 @@
-from .parse import parse_idl, Field, Struct, Module, Constant, Enum
+from .parse import parse_idl, Field, Struct, Module, Constant, Enum, Typedef, Union
 
-__all__ = ["parse_idl", "Field", "Struct", "Module", "Constant", "Enum"]
+__all__ = [
+    "parse_idl",
+    "Field",
+    "Struct",
+    "Module",
+    "Constant",
+    "Enum",
+    "Typedef",
+    "Union",
+]

--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional, Union as TypingUnion
 
 from lark import Lark, Transformer
 
-# A slightly larger subset grammar supporting modules, structs, constants and enums
+# A slightly larger subset grammar supporting modules, structs, constants, enums,
+# typedefs and unions
 IDL_GRAMMAR = r"""
 start: definition+
 
@@ -13,6 +14,8 @@ definition: module
           | struct
           | constant
           | enum
+          | typedef
+          | union
 
 module: "module" NAME "{" definition* "}" semicolon?
 
@@ -45,6 +48,13 @@ array: "[" INT "]"
 
 semicolon: ";"
 
+typedef: "typedef" type NAME array? semicolon
+
+union: "union" NAME "switch" "(" type ")" "{" (union_case | default_case)+ "}" semicolon?
+union_case: case_label+ field
+case_label: "case" const_value ":"
+default_case: "default" ":" field
+
 %import common.INT
 %import common.SIGNED_INT
 %import common.ESCAPED_STRING -> STRING
@@ -64,7 +74,7 @@ class Field:
 class Constant:
     name: str
     type: str
-    value: Union[int, str]
+    value: TypingUnion[int, str]
 
 
 @dataclass
@@ -80,7 +90,28 @@ class Struct:
 @dataclass
 class Module:
     name: str
-    definitions: List[Struct | Module | Constant | Enum] = field(default_factory=list)
+    definitions: List[Struct | Module | Constant | Enum | "Typedef" | "Union"] = field(default_factory=list)
+
+
+@dataclass
+class Typedef:
+    name: str
+    type: str
+    array_length: Optional[int] = None
+    is_sequence: bool = False
+
+
+@dataclass
+class UnionCase:
+    labels: List[TypingUnion[int, str]] = field(default_factory=list)
+    field: Field = field(default_factory=lambda: Field("", ""))
+
+
+@dataclass
+class Union:
+    name: str
+    switch_type: str
+    cases: List[UnionCase] = field(default_factory=list)
 
 class _Transformer(Transformer):
     _NORMALIZATION = {
@@ -199,6 +230,36 @@ class _Transformer(Transformer):
             constants.append(Constant(name=enum_name, type="uint32", value=current))
         return Enum(name=name, enumerators=constants)
 
+    def typedef(self, items):
+        type_, name, *rest = items
+        array_length = None
+        for itm in rest:
+            if isinstance(itm, int):
+                array_length = itm
+        is_sequence = False
+        if isinstance(type_, tuple) and type_[0] == "sequence":
+            is_sequence = True
+            type_ = type_[1]
+        return Typedef(name=name, type=type_, array_length=array_length, is_sequence=is_sequence)
+
+    def case_label(self, items):
+        (value,) = items
+        return value
+
+    def union_case(self, items):
+        *labels, field = items
+        return UnionCase(labels=labels, field=field)
+
+    def default_case(self, items):
+        (field,) = items
+        return UnionCase(labels=["default"], field=field)
+
+    def union(self, items):
+        name = items[0]
+        switch_type = items[1]
+        cases = [c for c in items[2:] if isinstance(c, UnionCase)]
+        return Union(name=name, switch_type=switch_type, cases=cases)
+
     def struct(self, items):
         name = items[0]
         fields = [i for i in items[1:] if isinstance(i, Field)]
@@ -209,23 +270,80 @@ class _Transformer(Transformer):
         definitions = [item for item in items[1:] if item is not None]
         return Module(name=name, definitions=definitions)
 
-    def resolve_types(self, definitions: List[Struct | Module | Constant | Enum]):
+    def resolve_types(self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]):
         struct_names: set[str] = set()
+        typedefs: dict[str, Typedef] = {}
 
-        def collect(defs: List[Struct | Module | Constant | Enum], scope: List[str]):
+        def collect(defs: List[Struct | Module | Constant | Enum | Typedef | Union], scope: List[str]):
             for d in defs:
-                if isinstance(d, Struct):
+                if isinstance(d, (Struct, Union)):
                     full = "::".join([*scope, d.name])
                     struct_names.add(full)
+                elif isinstance(d, Typedef):
+                    full = "::".join([*scope, d.name])
+                    typedefs[full] = d
                 elif isinstance(d, Module):
                     collect(d.definitions, [*scope, d.name])
 
         collect(definitions, [])
 
-        def resolve(defs: List[Struct | Module | Constant | Enum], scope: List[str]):
+        def apply_typedef(field: Field, scope: List[str]):
+            while True:
+                td = typedefs.get(field.type)
+                if td is None and not field.type.startswith("::"):
+                    for i in range(len(scope), -1, -1):
+                        candidate = "::".join([*scope[:i], field.type])
+                        td = typedefs.get(candidate)
+                        if td:
+                            break
+                if td is None:
+                    break
+                field.type = td.type
+                if field.array_length is None:
+                    field.array_length = td.array_length
+                if not field.is_sequence:
+                    field.is_sequence = td.is_sequence
+
+        def resolve_typedef_type(name: str, scope: List[str]) -> str:
+            t = name
+            while True:
+                td = typedefs.get(t)
+                if td is None and not t.startswith("::"):
+                    for i in range(len(scope), -1, -1):
+                        candidate = "::".join([*scope[:i], t])
+                        td = typedefs.get(candidate)
+                        if td:
+                            break
+                if td is None:
+                    break
+                t = td.type
+            return t
+
+        def resolve(defs: List[Struct | Module | Constant | Enum | Typedef | Union], scope: List[str]):
             for d in defs:
                 if isinstance(d, Struct):
                     for f in d.fields:
+                        apply_typedef(f, scope)
+                        if f.type in self._BUILTIN_TYPES:
+                            continue
+                        if f.type.startswith("::"):
+                            f.type = f.type[2:]
+                            continue
+                        if "::" in f.type:
+                            continue
+                        resolved = None
+                        for i in range(len(scope), -1, -1):
+                            candidate = "::".join([*scope[:i], f.type])
+                            if candidate in struct_names:
+                                resolved = candidate
+                                break
+                        if resolved:
+                            f.type = resolved
+                elif isinstance(d, Union):
+                    d.switch_type = resolve_typedef_type(d.switch_type, scope)
+                    for c in d.cases:
+                        f = c.field
+                        apply_typedef(f, scope)
                         if f.type in self._BUILTIN_TYPES:
                             continue
                         if f.type.startswith("::"):
@@ -247,7 +365,7 @@ class _Transformer(Transformer):
         resolve(definitions, [])
 
 
-def parse_idl(source: str) -> List[Struct | Module | Constant | Enum]:
+def parse_idl(source: str) -> List[Struct | Module | Constant | Enum | Typedef | Union]:
     parser = Lark(IDL_GRAMMAR, start="start")
     tree = parser.parse(source)
     transformer = _Transformer()

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -1,6 +1,16 @@
 import unittest
 
-from omgidl_parser.parse import parse_idl, Struct, Field, Module, Constant, Enum
+from omgidl_parser.parse import (
+    parse_idl,
+    Struct,
+    Field,
+    Module,
+    Constant,
+    Enum,
+    Typedef,
+    Union,
+    UnionCase,
+)
 
 class TestParseIDL(unittest.TestCase):
     def test_parse_struct(self):
@@ -135,6 +145,42 @@ class TestParseIDL(unittest.TestCase):
                                 Struct(name="B", fields=[Field(name="a", type="outer::A", array_length=None)])
                             ],
                         ),
+                    ],
+                )
+            ],
+        )
+
+    def test_typedef(self):
+        schema = """
+        typedef int32 MyInt;
+        struct A { MyInt value; };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Typedef(name="MyInt", type="int32"),
+                Struct(name="A", fields=[Field(name="value", type="int32", array_length=None)]),
+            ],
+        )
+
+    def test_union(self):
+        schema = """
+        union MyUnion switch (uint8) {
+            case 0: int32 i;
+            case 1: float32 f;
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Union(
+                    name="MyUnion",
+                    switch_type="uint8",
+                    cases=[
+                        UnionCase(labels=[0], field=Field(name="i", type="int32", array_length=None)),
+                        UnionCase(labels=[1], field=Field(name="f", type="float32", array_length=None)),
                     ],
                 )
             ],

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -46,6 +46,32 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_union(self):
+        schema = """
+        module pkg {
+          module msg {
+            union Foo switch (uint8) {
+              case 0: int32 i;
+              case 1: float32 f;
+            };
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="pkg/msg/Foo",
+                    definitions=[
+                        MessageDefinitionField(type="uint8", name="_type"),
+                        MessageDefinitionField(type="int32", name="i"),
+                        MessageDefinitionField(type="float32", name="f"),
+                    ],
+                )
+            ],
+        )
+
     def test_builtin_time_normalization(self):
         schema = """
         module builtin_interfaces {
@@ -89,6 +115,28 @@ class TestParseRos2idl(unittest.TestCase):
                     name="pkg/msg/Seq",
                     definitions=[
                         MessageDefinitionField(type="int32", name="data", isArray=True)
+                    ],
+                )
+            ],
+        )
+
+    def test_typedef(self):
+        schema = """
+        module pkg {
+          module msg {
+            typedef int32 MyInt;
+            struct A { MyInt value; };
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="pkg/msg/A",
+                    definitions=[
+                        MessageDefinitionField(type="int32", name="value")
                     ],
                 )
             ],


### PR DESCRIPTION
## Summary
- extend IDL grammar with typedef and union
- support typedef/union structures in ROS2 IDL conversion
- enable serialization and parsing tests for typedefs and unions

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests`

------
https://chatgpt.com/codex/tasks/task_e_688f1597ce9083308de052de57f03f1f