### PR TITLE
Support constant expressions in IDL parser

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -24,9 +24,11 @@ enumerator: NAME enum_value?
 enum_value: "@value" "(" INT ")"
 
 constant: "const" type NAME "=" const_value semicolon
-const_value: SIGNED_INT
-           | STRING
-           | NAME
+const_value: STRING -> const_string
+           | const_atom ("+" const_atom)*
+
+?const_atom: SIGNED_INT
+          | scoped_name
 
 field: type NAME array? semicolon
 
@@ -115,6 +117,11 @@ class _Transformer(Transformer):
         "boolean",
     }
 
+    def __init__(self):
+        super().__init__()
+        # Map identifiers (constants and enum values) to their evaluated numeric values
+        self._constants: dict[str, int | str] = {}
+
     def start(self, items):
         return list(items)
 
@@ -168,14 +175,33 @@ class _Transformer(Transformer):
             type_ = type_[1]
         return Field(name=name, type=type_, array_length=array_length, is_sequence=is_sequence)
 
-    def const_value(self, items):
+    def const_string(self, items):
         (value,) = items
         return value
+
+    def const_value(self, items):
+        total = 0
+        for idx, item in enumerate(items):
+            if isinstance(item, int):
+                val = item
+            else:
+                if item not in self._constants:
+                    raise ValueError(f"Unknown identifier '{item}'")
+                val = self._constants[item]
+                if not isinstance(val, int):
+                    raise ValueError(f"Identifier '{item}' does not evaluate to an integer")
+            if idx == 0:
+                total = val
+            else:
+                total += val
+        return total
 
     def constant(self, items):
         # items: TYPE, NAME, value, None
         type_, name, value, _ = items
-        return Constant(name=name, type=type_, value=value)
+        const = Constant(name=name, type=type_, value=value)
+        self._constants[name] = value
+        return const
 
     def enum_value(self, items):
         (_, _, val, _) = items
@@ -197,6 +223,9 @@ class _Transformer(Transformer):
             else:
                 current += 1
             constants.append(Constant(name=enum_name, type="uint32", value=current))
+            # Register enumerator both as unscoped and scoped (EnumName::Enumerator)
+            self._constants[enum_name] = current
+            self._constants[f"{name}::{enum_name}"] = current
         return Enum(name=name, enumerators=constants)
 
     def struct(self, items):

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -140,5 +140,46 @@ class TestParseIDL(unittest.TestCase):
             ],
         )
 
+    def test_constant_expression(self):
+        schema = """\
+        const long A = 1;
+        const long B = A + 1;
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Constant(name="A", type="int32", value=1),
+                Constant(name="B", type="int32", value=2),
+            ],
+        )
+
+    def test_constant_enum_reference(self):
+        schema = """\
+        enum COLORS {
+            RED,
+            GREEN,
+            BLUE
+        };
+        const short FOO = COLORS::GREEN + 2;
+        const short BAR = BLUE;
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Enum(
+                    name="COLORS",
+                    enumerators=[
+                        Constant(name="RED", type="uint32", value=0),
+                        Constant(name="GREEN", type="uint32", value=1),
+                        Constant(name="BLUE", type="uint32", value=2),
+                    ],
+                ),
+                Constant(name="FOO", type="int16", value=3),
+                Constant(name="BAR", type="int16", value=2),
+            ],
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow constant values to include identifiers and `+` expressions
- resolve constants and enum members during transformation
- test constant expressions and enum references

## Testing
- `PYTHONPATH=python_omgidl pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f15a543388330811346e7681e2477