### PR TITLE
feat: add typedef and union parsing

### DIFF
--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -1,3 +1,23 @@
-from .parse import parse_idl, Field, Struct, Module, Constant, Enum
+from .parse import (
+    parse_idl,
+    Field,
+    Struct,
+    Module,
+    Constant,
+    Enum,
+    Typedef,
+    Union,
+    UnionCase,
+)
 
-__all__ = ["parse_idl", "Field", "Struct", "Module", "Constant", "Enum"]
+__all__ = [
+    "parse_idl",
+    "Field",
+    "Struct",
+    "Module",
+    "Constant",
+    "Enum",
+    "Typedef",
+    "Union",
+    "UnionCase",
+]

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -11,6 +11,8 @@ from omgidl_parser.parse import (
     Module as IDLModule,
     Constant as IDLConstant,
     Enum as IDLEnum,
+    Typedef as IDLTypedef,
+    Union as IDLUnion,
 )
 
 
@@ -43,9 +45,10 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
     """Parse ros2idl schema into message definitions."""
     idl_conformed = ROS2IDL_HEADER.sub("", message_definition)
     parsed = parse_idl(idl_conformed)
+    typedefs = _collect_typedefs(parsed, [])
     message_defs: List[MessageDefinition] = []
     for definition in parsed:
-        message_defs.extend(_process_definition(definition, []))
+        message_defs.extend(_process_definition(definition, [], typedefs))
 
     for msg in message_defs:
         if msg.name is not None:
@@ -61,40 +64,75 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
     return message_defs
 
 
-def _process_definition(defn: IDLStruct | IDLModule | IDLConstant | IDLEnum, scope: List[str]) -> List[MessageDefinition]:
+def _process_definition(
+    defn: IDLStruct | IDLModule | IDLConstant | IDLEnum | IDLUnion | IDLTypedef,
+    scope: List[str],
+    typedefs: dict[str, IDLTypedef],
+) -> List[MessageDefinition]:
     results: List[MessageDefinition] = []
     if isinstance(defn, IDLStruct):
-        fields = [_convert_field(f) for f in defn.fields]
+        fields = [_convert_field(f, typedefs) for f in defn.fields]
+        results.append(MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields))
+    elif isinstance(defn, IDLUnion):
+        switch_type = _resolve_type(defn.switch_type, typedefs)
+        fields = [MessageDefinitionField(type=switch_type, name="_d")]
+        for case in defn.cases:
+            fields.append(_convert_field(case.field, typedefs))
+        if defn.default:
+            fields.append(_convert_field(defn.default, typedefs))
         results.append(MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields))
     elif isinstance(defn, IDLModule):
-        const_fields = [_convert_constant(c) for c in defn.definitions if isinstance(c, IDLConstant)]
+        const_fields = [
+            _convert_constant(c, typedefs)
+            for c in defn.definitions
+            if isinstance(c, IDLConstant)
+        ]
         if const_fields:
             results.append(
                 MessageDefinition(name="/".join([*scope, defn.name]), definitions=const_fields)
             )
         for sub in defn.definitions:
-            if isinstance(sub, (IDLModule, IDLStruct)):
-                results.extend(_process_definition(sub, [*scope, defn.name]))
+            if isinstance(sub, (IDLModule, IDLStruct, IDLUnion)):
+                results.extend(_process_definition(sub, [*scope, defn.name], typedefs))
     elif isinstance(defn, IDLConstant):
         results.append(
-            MessageDefinition(name="/".join(scope), definitions=[_convert_constant(defn)])
+            MessageDefinition(
+                name="/".join(scope), definitions=[_convert_constant(defn, typedefs)]
+            )
         )
+    # IDLEnum and IDLTypedef do not directly produce MessageDefinitions here
     return results
 
 
-def _convert_field(field: IDLField) -> MessageDefinitionField:
+def _convert_field(field: IDLField, typedefs: dict[str, IDLTypedef]) -> MessageDefinitionField:
+    t = field.type
+    array_length = field.array_length
+    is_sequence = field.is_sequence
+    seq_bound = field.sequence_bound
+    visited: set[str] = set()
+    while t in typedefs and t not in visited:
+        visited.add(t)
+        td = typedefs[t]
+        t = td.type
+        if td.array_length is not None and array_length is None and not is_sequence:
+            array_length = td.array_length
+        if td.is_sequence:
+            is_sequence = True
+            if td.sequence_bound is not None:
+                seq_bound = td.sequence_bound
     return MessageDefinitionField(
-        type=field.type,
+        type=t,
         name=field.name,
-        isArray=field.array_length is not None or field.is_sequence,
-        arrayLength=field.array_length,
-        arrayUpperBound=field.sequence_bound if field.is_sequence else None,
+        isArray=array_length is not None or is_sequence,
+        arrayLength=array_length,
+        arrayUpperBound=seq_bound if is_sequence else None,
     )
 
 
-def _convert_constant(const: IDLConstant) -> MessageDefinitionField:
+def _convert_constant(const: IDLConstant, typedefs: dict[str, IDLTypedef]) -> MessageDefinitionField:
+    t = _resolve_type(const.type, typedefs)
     return MessageDefinitionField(
-        type=const.type,
+        type=t,
         name=const.name,
         isConstant=True,
         value=const.value,
@@ -104,3 +142,33 @@ def _convert_constant(const: IDLConstant) -> MessageDefinitionField:
 
 def _normalize_name(name: str) -> str:
     return name.replace("::", "/") if "::" in name else name
+
+
+def _collect_typedefs(
+    defs: List[IDLStruct | IDLModule | IDLConstant | IDLEnum | IDLTypedef | IDLUnion],
+    scope: List[str],
+) -> dict[str, IDLTypedef]:
+    typedefs: dict[str, IDLTypedef] = {}
+
+    def collect(
+        ds: List[IDLStruct | IDLModule | IDLConstant | IDLEnum | IDLTypedef | IDLUnion],
+        sc: List[str],
+    ):
+        for d in ds:
+            if isinstance(d, IDLTypedef):
+                typedefs["::".join([*sc, d.name])] = d
+            elif isinstance(d, IDLModule):
+                collect(d.definitions, [*sc, d.name])
+
+    collect(defs, scope)
+    return typedefs
+
+
+def _resolve_type(name: str, typedefs: dict[str, IDLTypedef]) -> str:
+    t = name
+    visited: set[str] = set()
+    while t in typedefs and t not in visited:
+        visited.add(t)
+        td = typedefs[t]
+        t = td.type
+    return t

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -1,6 +1,16 @@
 import unittest
 
-from omgidl_parser.parse import parse_idl, Struct, Field, Module, Constant, Enum
+from omgidl_parser.parse import (
+    parse_idl,
+    Struct,
+    Field,
+    Module,
+    Constant,
+    Enum,
+    Typedef,
+    Union,
+    UnionCase,
+)
 
 class TestParseIDL(unittest.TestCase):
     def test_parse_struct(self):
@@ -203,6 +213,44 @@ class TestParseIDL(unittest.TestCase):
                 ),
                 Constant(name="FOO", type="int16", value=3),
                 Constant(name="BAR", type="int16", value=2),
+            ],
+        )
+
+    def test_typedef(self):
+        schema = """
+        typedef long MyLong;
+        struct Holder { MyLong value; };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Typedef(name="MyLong", type="int32"),
+                Struct(name="Holder", fields=[Field(name="value", type="MyLong")]),
+            ],
+        )
+
+    def test_union(self):
+        schema = """
+        union MyUnion switch (uint8) {
+            case 0: int32 a;
+            case 1: string b;
+            default: float c;
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Union(
+                    name="MyUnion",
+                    switch_type="uint8",
+                    cases=[
+                        UnionCase(value=0, field=Field(name="a", type="int32")),
+                        UnionCase(value=1, field=Field(name="b", type="string")),
+                    ],
+                    default=Field(name="c", type="float32"),
+                )
             ],
         )
 

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -122,6 +122,52 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_typedef_resolution(self):
+        schema = """
+        typedef long MyLong;
+        struct Holder { MyLong data; };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="Holder",
+                    definitions=[MessageDefinitionField(type="int32", name="data")],
+                )
+            ],
+        )
+
+    def test_union_definition(self):
+        schema = """
+        typedef long MyLong;
+        union MyUnion switch (uint8) {
+          case 0: MyLong as_long;
+          case 1: string as_string;
+        };
+        struct Container { MyUnion value; };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="MyUnion",
+                    definitions=[
+                        MessageDefinitionField(type="uint8", name="_d"),
+                        MessageDefinitionField(type="int32", name="as_long"),
+                        MessageDefinitionField(type="string", name="as_string"),
+                    ],
+                ),
+                MessageDefinition(
+                    name="Container",
+                    definitions=[
+                        MessageDefinitionField(type="MyUnion", name="value")
+                    ],
+                ),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support `typedef` and `union` grammar in omgidl parser
- convert typedefs and unions in ros2idl parsing
- test typedef and union parsing and conversion

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests`

------
https://chatgpt.com/codex/tasks/task_e_688f326a93088330a3353b013d3cf562