### PR TITLE
Add import and comment skipping to IDL parser

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -16,6 +16,8 @@ definition: module
           | enum
           | typedef
           | union
+          | import_stmt
+          | include_stmt
 
 module: "module" NAME "{" definition* "}" semicolon?
 
@@ -41,6 +43,10 @@ union_default: "default" ":" field
 
 field: type NAME array? semicolon
 
+import_stmt: "import" STRING semicolon
+
+include_stmt: "#include" (STRING | "<" /[^>]+/ ">")
+
 type: sequence_type
     | BUILTIN_TYPE
     | scoped_name
@@ -60,7 +66,10 @@ semicolon: ";"
 %import common.SIGNED_INT
 %import common.ESCAPED_STRING -> STRING
 %import common.WS
+
+COMMENT: /\/\/[^\n]*|\/\*[\s\S]*?\*\//
 %ignore WS
+%ignore COMMENT
 """
 
 @dataclass
@@ -155,7 +164,7 @@ class _Transformer(Transformer):
         self._constants: dict[str, int | str] = {}
 
     def start(self, items):
-        return list(items)
+        return [item for item in items if item is not None]
 
     def definition(self, items):
         return items[0]
@@ -194,6 +203,12 @@ class _Transformer(Transformer):
         return length
 
     def semicolon(self, _):
+        return None
+
+    def import_stmt(self, _items):
+        return None
+
+    def include_stmt(self, _items):
         return None
 
     def field(self, items):

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -254,5 +254,32 @@ class TestParseIDL(unittest.TestCase):
             ],
         )
 
+    def test_skip_import_and_include(self):
+        schema = """
+        import "foo.idl";
+        #include "bar.idl"
+        struct A { int32 x; };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [Struct(name="A", fields=[Field(name="x", type="int32", array_length=None)])],
+        )
+
+    def test_ignore_comments(self):
+        schema = """
+        // line comment
+        /* block
+           comment */
+        struct A {
+            int32 x; // trailing comment
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [Struct(name="A", fields=[Field(name="x", type="int32", array_length=None)])],
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend OMG IDL grammar to parse `import` and `#include` directives and to ignore `//` and `/* */` comments
- ensure transformer drops imports and includes so only real definitions are returned
- test that comments and includes/imports are skipped correctly

## Testing
- `PYTHONPATH=python_omgidl pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f39f13bc88330b706b5ae4e83d4c2