### PR TITLE
Extend const_value to support additional types

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -28,9 +28,13 @@ enum_value: "@value" "(" INT ")"
 
 constant: "const" type NAME "=" const_value semicolon
 const_value: STRING -> const_string
-           | const_atom ("+" const_atom)*
+           | BOOL -> const_bool
+           | const_sum
 
-?const_atom: SIGNED_INT
+const_sum: const_atom ("+" const_atom)*
+
+?const_atom: SIGNED_INT -> const_int
+          | SIGNED_FLOAT -> const_float
           | scoped_name
 
 typedef: "typedef" type NAME array? semicolon
@@ -57,7 +61,9 @@ array: "[" INT "]"
 semicolon: ";"
 
 %import common.INT
+BOOL.2: /(?i)true|false/
 %import common.SIGNED_INT
+%import common.SIGNED_FLOAT
 %import common.ESCAPED_STRING -> STRING
 %import common.WS
 %ignore WS
@@ -76,7 +82,7 @@ class Field:
 class Constant:
     name: str
     type: str
-    value: Union[int, str]
+    value: Union[int, float, bool, str]
 
 
 @dataclass
@@ -152,7 +158,7 @@ class _Transformer(Transformer):
     def __init__(self):
         super().__init__()
         # Map identifiers (constants and enum values) to their evaluated numeric values
-        self._constants: dict[str, int | str] = {}
+        self._constants: dict[str, int | float | bool | str] = {}
 
     def start(self, items):
         return list(items)
@@ -183,11 +189,13 @@ class _Transformer(Transformer):
     def INT(self, token):
         return int(token)
 
-    def SIGNED_INT(self, token):
+    def const_int(self, items):
+        (token,) = items
         return int(token)
 
     def STRING(self, token):
         return str(token)[1:-1]
+
 
     def array(self, items):
         (length,) = items
@@ -220,22 +228,36 @@ class _Transformer(Transformer):
         (value,) = items
         return value
 
-    def const_value(self, items):
-        total = 0
+    def const_bool(self, items):
+        (token,) = items
+        return str(token).lower() == "true"
+
+    def const_float(self, items):
+        (token,) = items
+        return float(token)
+
+    def const_sum(self, items):
+        total = None
         for idx, item in enumerate(items):
-            if isinstance(item, int):
-                val = item
-            else:
+            if isinstance(item, str):
                 if item not in self._constants:
                     raise ValueError(f"Unknown identifier '{item}'")
                 val = self._constants[item]
-                if not isinstance(val, int):
-                    raise ValueError(f"Identifier '{item}' does not evaluate to an integer")
+            else:
+                val = item
             if idx == 0:
                 total = val
             else:
+                if not isinstance(total, (int, float)) or not isinstance(val, (int, float)):
+                    raise ValueError(
+                        "Addition only allowed on numeric constants"
+                    )
                 total += val
         return total
+
+    def const_value(self, items):
+        (value,) = items
+        return value
 
     def constant(self, items):
         # items: TYPE, NAME, value, None

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -216,6 +216,28 @@ class TestParseIDL(unittest.TestCase):
             ],
         )
 
+    def test_constant_types_and_references(self):
+        schema = """\
+        const float PI = 3.14;
+        const boolean FLAG = true;
+        const string GREETING = "hello";
+        const string GREETING2 = GREETING;
+        const float PI2 = PI;
+        const boolean FLAG2 = FLAG;
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Constant(name="PI", type="float32", value=3.14),
+                Constant(name="FLAG", type="boolean", value=True),
+                Constant(name="GREETING", type="string", value="hello"),
+                Constant(name="GREETING2", type="string", value="hello"),
+                Constant(name="PI2", type="float32", value=3.14),
+                Constant(name="FLAG2", type="boolean", value=True),
+            ],
+        )
+
     def test_typedef(self):
         schema = """
         typedef long MyLong;


### PR DESCRIPTION
## Summary
- allow float, boolean, string, and constant references in IDL constant values
- resolve these new constant types in the transformer
- add regression tests for new constant parsing

## Testing
- `PYTHONPATH=python_omgidl pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3ad9ccf88330b9b4588f32308fed