### PR TITLE
feat: support annotations and default values

### DIFF
--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -8,6 +8,7 @@ from .parse import (
     Typedef,
     Union,
     UnionCase,
+    Annotation,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "Typedef",
     "Union",
     "UnionCase",
+    "Annotation",
 ]

--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -70,6 +70,8 @@ class MessageWriter:
         new_offset = offset
         for field in definition:
             value = msg.get(field.name)
+            if value is None:
+                value = _get_default(field)
             new_offset = self._field_size(field, value, new_offset)
         return new_offset
 
@@ -145,6 +147,8 @@ class MessageWriter:
         new_offset = offset
         for field in definition:
             value = msg.get(field.name)
+            if value is None:
+                value = _get_default(field)
             new_offset = self._write_field(field, value, buffer, new_offset)
         return new_offset
 
@@ -270,3 +274,12 @@ def _find_struct(defs: List[Struct | Module], name: str) -> Optional[Struct]:
             if found is not None:
                 return found
     return None
+
+
+def _get_default(field: Field) -> Any:
+    ann = field.annotations.get("default")
+    if ann is None:
+        return None
+    if ann.value is not None:
+        return ann.value
+    return ann.named_params.get("value")

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -189,6 +189,18 @@ class TestParseIDL(unittest.TestCase):
             ],
         )
 
+    def test_field_with_annotation(self):
+        schema = """
+        struct A {
+            @default(value=5)
+            int32 num;
+        };
+        """
+        result = parse_idl(schema)
+        field = result[0].fields[0]
+        self.assertIn("default", field.annotations)
+        self.assertEqual(field.annotations["default"].named_params["value"], 5)
+
     def test_constant_enum_reference(self):
         schema = """\
         enum COLORS {

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any, Dict
 
 from omgidl_parser.parse import parse_idl, Struct, Field
 from omgidl_serialization import MessageWriter
@@ -112,6 +113,21 @@ class TestMessageWriter(unittest.TestCase):
             writer.write_message(over)
         with self.assertRaises(ValueError):
             writer.calculate_byte_size(over)
+
+    def test_default_annotation(self) -> None:
+        schema = """
+        struct A {
+            @default(value=5)
+            int32 num;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg: Dict[str, Any] = {}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend IDL grammar to parse annotations and attach them to AST nodes
- allow serializer to honor `@default` annotations when fields are omitted
- test annotation parsing and default value handling

## Testing
- `PYTHONPATH=python_omgidl pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3ae03eec83309ff0a67e793aa5bc