### PR TITLE
Add configurable CDR encapsulation and endianness

### DIFF
--- a/python_omgidl/omgidl_serialization/__init__.py
+++ b/python_omgidl/omgidl_serialization/__init__.py
@@ -1,4 +1,4 @@
-from .message_writer import MessageWriter
+from .message_writer import MessageWriter, EncapsulationKind
 from .message_reader import MessageReader
 
-__all__ = ["MessageWriter", "MessageReader"]
+__all__ = ["MessageWriter", "MessageReader", "EncapsulationKind"]

--- a/python_omgidl/omgidl_serialization/message_reader.py
+++ b/python_omgidl/omgidl_serialization/message_reader.py
@@ -8,6 +8,8 @@ from omgidl_parser.parse import Struct, Field, Module
 from .message_writer import (
     PRIMITIVE_FORMATS,
     PRIMITIVE_SIZES,
+    EncapsulationKind,
+    _LITTLE_ENDIAN_KINDS,
     _find_struct,
     _padding,
     _primitive_size,
@@ -30,11 +32,16 @@ class MessageReader:
             )
         self.root = root
         self.definitions = definitions
+        self._fmt_prefix = "<"
+        self.encapsulation_kind = EncapsulationKind.CDR_LE
 
     # public API -------------------------------------------------------------
     def read_message(self, buffer: bytes | bytearray | memoryview) -> Dict[str, Any]:
         view = buffer if isinstance(buffer, memoryview) else memoryview(buffer)
-        # skip CDR header for little-endian PL_CDR2
+        kind = EncapsulationKind(view[1])
+        self.encapsulation_kind = kind
+        little = kind in _LITTLE_ENDIAN_KINDS
+        self._fmt_prefix = "<" if little else ">"
         offset = 4
         msg, _ = self._read(self.root.fields, view, offset)
         return msg
@@ -56,7 +63,7 @@ class MessageReader:
                 arr: List[str] = []
                 for _ in range(field.array_length):
                     offset += _padding(offset, 4)
-                    length = struct.unpack_from("<I", view, offset)[0]
+                    length = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
                     offset += 4
                     data = bytes(view[offset : offset + length - 1])
                     offset += length
@@ -64,7 +71,7 @@ class MessageReader:
                 return arr, offset
             elif t in PRIMITIVE_SIZES:
                 size = _primitive_size(t)
-                fmt = "<" + PRIMITIVE_FORMATS[t]
+                fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                 arr: List[Any] = []
                 offset += _padding(offset, size)
                 for _ in range(field.array_length):
@@ -87,20 +94,20 @@ class MessageReader:
             if field.is_sequence:
                 # Variable-length sequence
                 offset += _padding(offset, 4)
-                length = struct.unpack_from("<I", view, offset)[0]
+                length = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
                 offset += 4
                 arr: List[Any] = []
                 if t == "string":
                     for _ in range(length):
                         offset += _padding(offset, 4)
-                        slen = struct.unpack_from("<I", view, offset)[0]
+                        slen = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
                         offset += 4
                         data = bytes(view[offset : offset + slen - 1])
                         offset += slen
                         arr.append(data.decode("utf-8"))
                 elif t in PRIMITIVE_SIZES:
                     size = _primitive_size(t)
-                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                     offset += _padding(offset, size)
                     for _ in range(length):
                         val = struct.unpack_from(fmt, view, offset)[0]
@@ -119,14 +126,14 @@ class MessageReader:
             else:
                 if t == "string":
                     offset += _padding(offset, 4)
-                    length = struct.unpack_from("<I", view, offset)[0]
+                    length = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
                     offset += 4
                     data = bytes(view[offset : offset + length - 1])
                     offset += length
                     return data.decode("utf-8"), offset
                 elif t in PRIMITIVE_SIZES:
                     size = _primitive_size(t)
-                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                     offset += _padding(offset, size)
                     val = struct.unpack_from(fmt, view, offset)[0]
                     offset += size

--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+from enum import IntEnum
 from typing import List, Dict, Any, Optional
 
 from omgidl_parser.parse import Struct, Field, Module
@@ -35,15 +36,61 @@ PRIMITIVE_FORMATS: Dict[str, str] = {
 }
 
 
+class EncapsulationKind(IntEnum):
+    """Encapsulation header representation identifiers."""
+
+    CDR_BE = 0x00
+    CDR_LE = 0x01
+    PL_CDR_BE = 0x02
+    PL_CDR_LE = 0x03
+    CDR2_BE = 0x10
+    CDR2_LE = 0x11
+    PL_CDR2_BE = 0x12
+    PL_CDR2_LE = 0x13
+    DELIMITED_CDR2_BE = 0x14
+    DELIMITED_CDR2_LE = 0x15
+    RTPS_CDR2_BE = 0x06
+    RTPS_CDR2_LE = 0x07
+    RTPS_DELIMITED_CDR2_BE = 0x08
+    RTPS_DELIMITED_CDR2_LE = 0x09
+    RTPS_PL_CDR2_BE = 0x0A
+    RTPS_PL_CDR2_LE = 0x0B
+
+
+_LITTLE_ENDIAN_KINDS = {
+    EncapsulationKind.CDR_LE,
+    EncapsulationKind.PL_CDR_LE,
+    EncapsulationKind.CDR2_LE,
+    EncapsulationKind.PL_CDR2_LE,
+    EncapsulationKind.DELIMITED_CDR2_LE,
+    EncapsulationKind.RTPS_CDR2_LE,
+    EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+    EncapsulationKind.RTPS_PL_CDR2_LE,
+}
+
+
+def _encapsulation_header(kind: EncapsulationKind) -> bytes:
+    """Return the 4-byte encapsulation header for ``kind``."""
+    return bytes((0, int(kind), 0, 0))
+
+
 class MessageWriter:
     """Serialize Python dictionaries to CDR-encoded bytes.
 
     This is a minimal Python port of the TypeScript MessageWriter. It supports
     primitive fields, fixed-length arrays, and variable-length sequences as
     produced by the simplified ``parse_idl`` parser.
+
+    ``encapsulation_kind`` selects the representation identifier written to the
+    start of each message. ``EncapsulationKind.CDR_LE`` is used by default.
     """
 
-    def __init__(self, root_definition_name: str, definitions: List[Struct | Module]) -> None:
+    def __init__(
+        self,
+        root_definition_name: str,
+        definitions: List[Struct | Module],
+        encapsulation_kind: EncapsulationKind = EncapsulationKind.CDR_LE,
+    ) -> None:
         root = _find_struct(definitions, root_definition_name)
         if root is None:
             raise ValueError(
@@ -51,6 +98,9 @@ class MessageWriter:
             )
         self.root = root
         self.definitions = definitions
+        self.encapsulation_kind = encapsulation_kind
+        self._little_endian = encapsulation_kind in _LITTLE_ENDIAN_KINDS
+        self._fmt_prefix = "<" if self._little_endian else ">"
 
     # public API -------------------------------------------------------------
     def calculate_byte_size(self, message: Dict[str, Any]) -> int:
@@ -59,8 +109,7 @@ class MessageWriter:
     def write_message(self, message: Dict[str, Any]) -> bytes:
         size = self.calculate_byte_size(message)
         buffer = bytearray(size)
-        # CDR header for little-endian PL_CDR2
-        buffer[0:4] = b"\x00\x01\x00\x00"
+        buffer[0:4] = _encapsulation_header(self.encapsulation_kind)
         self._write(self.root.fields, message, buffer, 4)
         return bytes(buffer)
 
@@ -159,7 +208,7 @@ class MessageWriter:
                     offset += _padding(offset, 4)
                     encoded = s.encode("utf-8")
                     length = len(encoded) + 1
-                    struct.pack_into("<I", buffer, offset, length)
+                    struct.pack_into(self._fmt_prefix + "I", buffer, offset, length)
                     offset += 4
                     buffer[offset:offset + len(encoded)] = encoded
                     offset += len(encoded)
@@ -167,7 +216,7 @@ class MessageWriter:
                     offset += 1
             elif t in PRIMITIVE_SIZES:
                 size = _primitive_size(t)
-                fmt = "<" + PRIMITIVE_FORMATS[t]
+                fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                 arr = value if isinstance(value, (list, tuple)) else []
                 offset += _padding(offset, size)
                 for i in range(field.array_length):
@@ -192,7 +241,7 @@ class MessageWriter:
                         f"Field '{field.name}' sequence length {length} exceeds bound {field.sequence_bound}"
                     )
                 offset += _padding(offset, 4)
-                struct.pack_into("<I", buffer, offset, length)
+                struct.pack_into(self._fmt_prefix + "I", buffer, offset, length)
                 offset += 4
                 if t == "string":
                     for s in arr:
@@ -200,7 +249,7 @@ class MessageWriter:
                         offset += _padding(offset, 4)
                         encoded = s.encode("utf-8")
                         length_s = len(encoded) + 1
-                        struct.pack_into("<I", buffer, offset, length_s)
+                        struct.pack_into(self._fmt_prefix + "I", buffer, offset, length_s)
                         offset += 4
                         buffer[offset:offset + len(encoded)] = encoded
                         offset += len(encoded)
@@ -208,7 +257,7 @@ class MessageWriter:
                         offset += 1
                 elif t in PRIMITIVE_SIZES:
                     size = _primitive_size(t)
-                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                     offset += _padding(offset, size)
                     for v in arr:
                         v = v if v is not None else 0
@@ -227,7 +276,7 @@ class MessageWriter:
                     offset += _padding(offset, 4)
                     encoded = s.encode("utf-8")
                     length = len(encoded) + 1
-                    struct.pack_into("<I", buffer, offset, length)
+                    struct.pack_into(self._fmt_prefix + "I", buffer, offset, length)
                     offset += 4
                     buffer[offset:offset + len(encoded)] = encoded
                     offset += len(encoded)
@@ -235,7 +284,7 @@ class MessageWriter:
                     offset += 1
                 elif t in PRIMITIVE_SIZES:
                     size = _primitive_size(t)
-                    fmt = "<" + PRIMITIVE_FORMATS[t]
+                    fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                     offset += _padding(offset, size)
                     v = value if value is not None else 0
                     struct.pack_into(fmt, buffer, offset, v)


### PR DESCRIPTION
## Summary
- add `EncapsulationKind` enum and allow choosing it in MessageWriter
- automatically detect endianness and header type in MessageReader
- cover big-endian and PL_CDR2 headers with unit tests

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3aec78848330940ed2d330a90b60