### PR TITLE
feat: support annotations and default values

### DIFF
--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -119,6 +119,8 @@ class MessageWriter:
         new_offset = offset
         for field in definition:
             value = msg.get(field.name)
+            if value is None and field.annotations.get("default") is not None:
+                value = field.annotations["default"]
             new_offset = self._field_size(field, value, new_offset)
         return new_offset
 
@@ -209,6 +211,8 @@ class MessageWriter:
         new_offset = offset
         for field in definition:
             value = msg.get(field.name)
+            if value is None and field.annotations.get("default") is not None:
+                value = field.annotations["default"]
             new_offset = self._write_field(field, value, buffer, new_offset)
         return new_offset
 

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -22,6 +22,32 @@ class TestParseIDL(unittest.TestCase):
         result = parse_idl(schema)
         self.assertEqual(result, [Struct(name="A", fields=[Field(name="num", type="int32", array_length=None)])])
 
+    def test_annotations(self):
+        schema = """
+        @topic
+        struct A {
+            @default(5) int32 num;
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Struct(
+                    name="A",
+                    fields=[
+                        Field(
+                            name="num",
+                            type="int32",
+                            array_length=None,
+                            annotations={"default": 5},
+                        )
+                    ],
+                    annotations={"topic": True},
+                )
+            ],
+        )
+
     def test_module_with_struct(self):
         schema = """
         module outer {

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -20,6 +20,21 @@ class TestMessageWriter(unittest.TestCase):
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
+    def test_default_annotation_used(self) -> None:
+        schema = """
+        struct A {
+            @default(5) int32 num;
+            uint8 flag;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg = {"flag": 7}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 7])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
     def test_uint8_array(self) -> None:
         schema = """
         struct A {


### PR DESCRIPTION
## Summary
- support annotations in Python OMG IDL grammar and AST
- add annotations attribute to Field, Struct, and other nodes
- use `@default` annotations during serialization

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl -q`

------
https://chatgpt.com/codex/tasks/task_e_688f406714308330af77110e87297864