### PR TITLE
Support multi-dimensional arrays

### DIFF
--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -106,7 +106,7 @@ def _process_definition(
 
 def _convert_field(field: IDLField, typedefs: dict[str, IDLTypedef]) -> MessageDefinitionField:
     t = field.type
-    array_length = field.array_length
+    array_lengths = list(field.array_lengths)
     is_sequence = field.is_sequence
     seq_bound = field.sequence_bound
     visited: set[str] = set()
@@ -114,8 +114,8 @@ def _convert_field(field: IDLField, typedefs: dict[str, IDLTypedef]) -> MessageD
         visited.add(t)
         td = typedefs[t]
         t = td.type
-        if td.array_length is not None and array_length is None and not is_sequence:
-            array_length = td.array_length
+        if td.array_lengths and not array_lengths and not is_sequence:
+            array_lengths = list(td.array_lengths)
         if td.is_sequence:
             is_sequence = True
             if td.sequence_bound is not None:
@@ -123,8 +123,8 @@ def _convert_field(field: IDLField, typedefs: dict[str, IDLTypedef]) -> MessageD
     return MessageDefinitionField(
         type=t,
         name=field.name,
-        isArray=array_length is not None or is_sequence,
-        arrayLength=array_length,
+        isArray=bool(array_lengths) or is_sequence,
+        arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=seq_bound if is_sequence else None,
     )
 

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -63,6 +63,20 @@ class TestMessageReader(unittest.TestCase):
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
 
+    def test_roundtrip_multidimensional_uint8_array(self) -> None:
+        schema = """
+        struct A {
+            uint8 data[2][3];
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"data": [[1, 2, 3], [4, 5, 6]]}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
     def test_roundtrip_string_field(self) -> None:
         schema = """
         struct A {

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -20,7 +20,7 @@ class TestParseIDL(unittest.TestCase):
         };
         """
         result = parse_idl(schema)
-        self.assertEqual(result, [Struct(name="A", fields=[Field(name="num", type="int32", array_length=None)])])
+        self.assertEqual(result, [Struct(name="A", fields=[Field(name="num", type="int32")])])
 
     def test_annotations(self):
         schema = """
@@ -39,7 +39,6 @@ class TestParseIDL(unittest.TestCase):
                         Field(
                             name="num",
                             type="int32",
-                            array_length=None,
                             annotations={"default": 5},
                         )
                     ],
@@ -58,7 +57,7 @@ class TestParseIDL(unittest.TestCase):
         """
         result = parse_idl(schema)
         self.assertEqual(result, [
-            Module(name="outer", definitions=[Struct(name="B", fields=[Field(name="val", type="uint8", array_length=None)])])
+            Module(name="outer", definitions=[Struct(name="B", fields=[Field(name="val", type="uint8")])])
         ])
 
     def test_fixed_array_field(self):
@@ -70,7 +69,19 @@ class TestParseIDL(unittest.TestCase):
         result = parse_idl(schema)
         self.assertEqual(
             result,
-            [Struct(name="A", fields=[Field(name="nums", type="int32", array_length=3)])],
+            [Struct(name="A", fields=[Field(name="nums", type="int32", array_lengths=[3])])],
+        )
+
+    def test_multidimensional_array_field(self):
+        schema = """
+        struct A {
+            int32 nums[2][3];
+        };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [Struct(name="A", fields=[Field(name="nums", type="int32", array_lengths=[2, 3])])],
         )
 
     def test_constant_in_module(self):
@@ -97,7 +108,7 @@ class TestParseIDL(unittest.TestCase):
                 Struct(
                     name="A",
                     fields=[
-                        Field(name="nums", type="int32", array_length=None, is_sequence=True)
+                        Field(name="nums", type="int32", is_sequence=True)
                     ],
                 )
             ],
@@ -119,7 +130,6 @@ class TestParseIDL(unittest.TestCase):
                         Field(
                             name="nums",
                             type="int32",
-                            array_length=None,
                             is_sequence=True,
                             sequence_bound=5,
                         )
@@ -144,7 +154,6 @@ class TestParseIDL(unittest.TestCase):
                         Field(
                             name="name",
                             type="string",
-                            array_length=None,
                             is_sequence=False,
                             sequence_bound=None,
                             string_upper_bound=5,
@@ -192,8 +201,8 @@ class TestParseIDL(unittest.TestCase):
                 Module(
                     name="outer",
                     definitions=[
-                        Struct(name="A", fields=[Field(name="num", type="int32", array_length=None)]),
-                        Struct(name="B", fields=[Field(name="a", type="outer::A", array_length=None)]),
+                        Struct(name="A", fields=[Field(name="num", type="int32")]),
+                        Struct(name="B", fields=[Field(name="a", type="outer::A")]),
                     ],
                 )
             ],
@@ -215,11 +224,11 @@ class TestParseIDL(unittest.TestCase):
                 Module(
                     name="outer",
                     definitions=[
-                        Struct(name="A", fields=[Field(name="num", type="int32", array_length=None)]),
+                        Struct(name="A", fields=[Field(name="num", type="int32")]),
                         Module(
                             name="inner",
                             definitions=[
-                                Struct(name="B", fields=[Field(name="a", type="outer::A", array_length=None)])
+                                Struct(name="B", fields=[Field(name="a", type="outer::A")])
                             ],
                         ),
                     ],
@@ -337,7 +346,7 @@ class TestParseIDL(unittest.TestCase):
         result = parse_idl(schema)
         self.assertEqual(
             result,
-            [Struct(name="A", fields=[Field(name="x", type="int32", array_length=None)])],
+            [Struct(name="A", fields=[Field(name="x", type="int32")])],
         )
 
     def test_ignore_comments(self):
@@ -352,7 +361,7 @@ class TestParseIDL(unittest.TestCase):
         result = parse_idl(schema)
         self.assertEqual(
             result,
-            [Struct(name="A", fields=[Field(name="x", type="int32", array_length=None)])],
+            [Struct(name="A", fields=[Field(name="x", type="int32")])],
         )
 
 if __name__ == "__main__":

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -49,6 +49,20 @@ class TestMessageWriter(unittest.TestCase):
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
+    def test_multidimensional_uint8_array(self) -> None:
+        schema = """
+        struct A {
+            uint8 data[2][3];
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        msg = {"data": [[1, 2, 3], [4, 5, 6]]}
+        written = writer.write_message(msg)
+        expected = bytes([0, 1, 0, 0, 1, 2, 3, 4, 5, 6])
+        self.assertEqual(written, expected)
+        self.assertEqual(writer.calculate_byte_size(msg), len(expected))
+
     def test_string_field(self) -> None:
         schema = """
         struct A {


### PR DESCRIPTION
## Summary
- handle repeated `[INT]` in OMG IDL arrays and track dimensions via `Field.array_lengths`
- teach serializer and reader to process multi-dimensional arrays
- cover multi-dimensional arrays with parsing and serialization tests

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests`
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688f420070508330be899e1b89e0f88f