### PR TITLE
Use typed arrays for primitive sequences

### DIFF
--- a/python_omgidl/omgidl_serialization/message_reader.py
+++ b/python_omgidl/omgidl_serialization/message_reader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+from array import array
 from typing import Any, Dict, List, Tuple
 
 from omgidl_parser.parse import Struct, Field, Module, Union as IDLUnion
@@ -67,8 +68,8 @@ class MessageReader:
                 offset += _padding(offset, 4)
                 length = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
                 offset += 4
-                arr: List[Any] = []
                 if t in ("string", "wstring"):
+                    arr: List[Any] = []
                     for _ in range(length):
                         offset += _padding(offset, 4)
                         slen = struct.unpack_from(self._fmt_prefix + "I", view, offset)[0]
@@ -86,6 +87,7 @@ class MessageReader:
                     size = _primitive_size(t)
                     fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
                     offset += _padding(offset, size)
+                    arr = array(PRIMITIVE_FORMATS[t])
                     for _ in range(length):
                         val = struct.unpack_from(fmt, view, offset)[0]
                         offset += size
@@ -93,6 +95,7 @@ class MessageReader:
                             val = bool(val)
                         arr.append(val)
                 else:
+                    arr: List[Any] = []
                     struct_def = _find_struct(self.definitions, t)
                     if struct_def is not None:
                         for _ in range(length):
@@ -171,7 +174,7 @@ class MessageReader:
         elif t in PRIMITIVE_SIZES:
             size = _primitive_size(t)
             fmt = self._fmt_prefix + PRIMITIVE_FORMATS[t]
-            arr: List[Any] = []
+            arr = array(PRIMITIVE_FORMATS[t])
             offset += _padding(offset, size)
             for _ in range(length):
                 val = struct.unpack_from(fmt, view, offset)[0]

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -1,5 +1,6 @@
 import unittest
 
+from array import array
 from omgidl_parser.parse import parse_idl, Struct, Field
 from omgidl_serialization import MessageWriter, MessageReader, EncapsulationKind
 
@@ -76,7 +77,7 @@ class TestMessageReader(unittest.TestCase):
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
         reader = MessageReader("A", defs)
-        msg = {"data": [1, 2, 3, 4]}
+        msg = {"data": array("B", [1, 2, 3, 4])}
         buf = writer.write_message(msg)
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
@@ -90,7 +91,7 @@ class TestMessageReader(unittest.TestCase):
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
         reader = MessageReader("A", defs)
-        msg = {"data": [[1, 2, 3], [4, 5, 6]]}
+        msg = {"data": [array("B", [1, 2, 3]), array("B", [4, 5, 6])]}
         buf = writer.write_message(msg)
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
@@ -157,7 +158,16 @@ class TestMessageReader(unittest.TestCase):
         defs = [Struct(name="A", fields=[Field(name="data", type="int32", is_sequence=True)])]
         writer = MessageWriter("A", defs)
         reader = MessageReader("A", defs)
-        msg = {"data": [3, 7]}
+        msg = {"data": array("i", [3, 7])}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_roundtrip_float_sequence_typed_array(self) -> None:
+        defs = [Struct(name="A", fields=[Field(name="data", type="float32", is_sequence=True)])]
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"data": array("f", [1.0, 2.0])}
         buf = writer.write_message(msg)
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)


### PR DESCRIPTION
## Summary
- use Python `array` for primitive sequences/arrays
- support typed arrays and memoryviews in serializer
- add tests covering typed-array round trips

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests/test_message_reader.py::TestMessageReader::test_roundtrip_float_sequence_typed_array python_omgidl/tests/test_message_reader.py::TestMessageReader::test_roundtrip_uint8_array python_omgidl/tests/test_serialization.py::TestMessageWriter::test_uint8_array -q`

------
https://chatgpt.com/codex/tasks/task_e_688f540a9b2c8330b0b7de4892c27497