### PR TITLE
feat: centralize union discriminator key

### DIFF
--- a/python_omgidl/omgidl_serialization/__init__.py
+++ b/python_omgidl/omgidl_serialization/__init__.py
@@ -1,5 +1,12 @@
 from .message_writer import MessageWriter, EncapsulationKind
 from .message_reader import MessageReader
 from .deserialization_info_cache import DeserializationInfoCache
+from .constants import UNION_DISCRIMINATOR_PROPERTY_KEY
 
-__all__ = ["MessageWriter", "MessageReader", "EncapsulationKind", "DeserializationInfoCache"]
+__all__ = [
+    "MessageWriter",
+    "MessageReader",
+    "EncapsulationKind",
+    "DeserializationInfoCache",
+    "UNION_DISCRIMINATOR_PROPERTY_KEY",
+]

--- a/python_omgidl/omgidl_serialization/constants.py
+++ b/python_omgidl/omgidl_serialization/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for OMG IDL serialization.
+
+Per: https://www.omg.org/spec/DDS-JSON/1.0/Beta1/PDF
+"""
+
+UNION_DISCRIMINATOR_PROPERTY_KEY = "$discriminator"
+

--- a/python_omgidl/omgidl_serialization/deserialization_info_cache.py
+++ b/python_omgidl/omgidl_serialization/deserialization_info_cache.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from omgidl_parser.parse import Field, Module, Struct, Union as IDLUnion
 
 from .message_writer import _find_struct, _find_union, _union_case_field
+from .constants import UNION_DISCRIMINATOR_PROPERTY_KEY
 
 DEFAULT_BOOLEAN_VALUE = False
 DEFAULT_NUMERICAL_VALUE = 0
@@ -156,18 +157,20 @@ class DeserializationInfoCache:
             if union_def.default is not None:
                 default_field_info = self.build_field_info(union_def.default)
                 msg = {
-                    "_d": None,
+                    UNION_DISCRIMINATOR_PROPERTY_KEY: None,
                     default_field_info.name: self.get_field_default(default_field_info),
                 }
             else:
-                disc_field_info = self.build_field_info(Field(name="_d", type=union_def.switch_type))
+                disc_field_info = self.build_field_info(
+                    Field(name=UNION_DISCRIMINATOR_PROPERTY_KEY, type=union_def.switch_type)
+                )
                 switch_val = self.get_field_default(disc_field_info)
                 case_field = _union_case_field(union_def, switch_val)
                 if case_field is None:
                     raise ValueError(f"Failed to find default case for union {union_def.name}")
                 case_info = self.build_field_info(case_field)
                 msg = {
-                    "_d": switch_val,
+                    UNION_DISCRIMINATOR_PROPERTY_KEY: switch_val,
                     case_info.name: self.get_field_default(case_info),
                 }
             info.default_value = msg

--- a/python_omgidl/omgidl_serialization/message_reader.py
+++ b/python_omgidl/omgidl_serialization/message_reader.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Tuple
 
 from omgidl_parser.parse import Struct, Field, Module, Union as IDLUnion
 
+from .constants import UNION_DISCRIMINATOR_PROPERTY_KEY
+
 from .message_writer import (
     PRIMITIVE_FORMATS,
     PRIMITIVE_SIZES,
@@ -208,10 +210,10 @@ class MessageReader:
     def _read_union(
         self, info: UnionDeserializationInfo, view: memoryview, offset: int
     ) -> Tuple[Dict[str, Any], int]:
-        disc_field = Field(name="_d", type=info.definition.switch_type)
+        disc_field = Field(name=UNION_DISCRIMINATOR_PROPERTY_KEY, type=info.definition.switch_type)
         disc_info = self.cache.build_field_info(disc_field)
         disc, offset = self._read_field(disc_info, view, offset)
-        msg: Dict[str, Any] = {"_d": disc}
+        msg: Dict[str, Any] = {UNION_DISCRIMINATOR_PROPERTY_KEY: disc}
         case_field = _union_case_field(info.definition, disc)
         if case_field is None:
             return msg, offset

--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -7,6 +7,8 @@ from typing import List, Dict, Any, Optional
 
 from omgidl_parser.parse import Struct, Field, Module, Union as IDLUnion
 
+from .constants import UNION_DISCRIMINATOR_PROPERTY_KEY
+
 
 PRIMITIVE_SIZES: Dict[str, int] = {
     "bool": 1,
@@ -400,8 +402,8 @@ class MessageWriter:
         return offset
 
     def _byte_size_union(self, union_def: IDLUnion, message: Dict[str, Any], offset: int) -> int:
-        disc_field = Field(name="_d", type=union_def.switch_type)
-        disc = message.get("_d")
+        disc_field = Field(name=UNION_DISCRIMINATOR_PROPERTY_KEY, type=union_def.switch_type)
+        disc = message.get(UNION_DISCRIMINATOR_PROPERTY_KEY)
         offset = self._field_size(disc_field, disc, offset)
         case_field = _union_case_field(union_def, disc)
         if case_field is None:
@@ -415,10 +417,12 @@ class MessageWriter:
     def _write_union(
         self, union_def: IDLUnion, message: Dict[str, Any], buffer: bytearray, offset: int
     ) -> int:
-        disc_field = Field(name="_d", type=union_def.switch_type)
-        disc = message.get("_d")
+        disc_field = Field(name=UNION_DISCRIMINATOR_PROPERTY_KEY, type=union_def.switch_type)
+        disc = message.get(UNION_DISCRIMINATOR_PROPERTY_KEY)
         if disc is None:
-            raise ValueError(f"Union {union_def.name} requires '_d' discriminator")
+            raise ValueError(
+                f"Union {union_def.name} requires '{UNION_DISCRIMINATOR_PROPERTY_KEY}' discriminator"
+            )
         offset = self._write_field(disc_field, disc, buffer, offset)
         case_field = _union_case_field(union_def, disc)
         if case_field is None:

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -15,6 +15,8 @@ from omgidl_parser.parse import (
     Union as IDLUnion,
 )
 
+from omgidl_serialization.constants import UNION_DISCRIMINATOR_PROPERTY_KEY
+
 
 @dataclass
 class MessageDefinitionField:
@@ -75,7 +77,11 @@ def _process_definition(
         results.append(MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields))
     elif isinstance(defn, IDLUnion):
         switch_type = _resolve_type(defn.switch_type, typedefs)
-        fields = [MessageDefinitionField(type=switch_type, name="_d")]
+        fields = [
+            MessageDefinitionField(
+                type=switch_type, name=UNION_DISCRIMINATOR_PROPERTY_KEY
+            )
+        ]
         for case in defn.cases:
             fields.append(_convert_field(case.field, typedefs))
         if defn.default:

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -2,7 +2,12 @@ import unittest
 from array import array
 
 from omgidl_parser.parse import parse_idl, Struct, Field
-from omgidl_serialization import MessageWriter, MessageReader, EncapsulationKind
+from omgidl_serialization import (
+    MessageWriter,
+    MessageReader,
+    EncapsulationKind,
+    UNION_DISCRIMINATOR_PROPERTY_KEY,
+)
 
 
 class TestMessageReader(unittest.TestCase):
@@ -34,7 +39,7 @@ class TestMessageReader(unittest.TestCase):
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
         reader = MessageReader("A", defs)
-        msg = {"u": {"_d": 0, "a": 7}}
+        msg = {"u": {UNION_DISCRIMINATOR_PROPERTY_KEY: 0, "a": 7}}
         buf = writer.write_message(msg)
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -1,6 +1,7 @@
 import unittest
 
 from ros2idl_parser import parse_ros2idl, MessageDefinition, MessageDefinitionField
+from omgidl_serialization import UNION_DISCRIMINATOR_PROPERTY_KEY
 
 
 class TestParseRos2idl(unittest.TestCase):
@@ -154,7 +155,9 @@ class TestParseRos2idl(unittest.TestCase):
                 MessageDefinition(
                     name="MyUnion",
                     definitions=[
-                        MessageDefinitionField(type="uint8", name="_d"),
+                        MessageDefinitionField(
+                            type="uint8", name=UNION_DISCRIMINATOR_PROPERTY_KEY
+                        ),
                         MessageDefinitionField(type="int32", name="as_long"),
                         MessageDefinitionField(type="string", name="as_string"),
                     ],

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -1,7 +1,7 @@
 import unittest
 
 from omgidl_parser.parse import parse_idl, Struct, Field
-from omgidl_serialization import MessageWriter
+from omgidl_serialization import MessageWriter, UNION_DISCRIMINATOR_PROPERTY_KEY
 
 
 class TestMessageWriter(unittest.TestCase):
@@ -108,7 +108,7 @@ class TestMessageWriter(unittest.TestCase):
         """
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
-        msg = {"u": {"_d": 1, "b": 42}}
+        msg = {"u": {UNION_DISCRIMINATOR_PROPERTY_KEY: 1, "b": 42}}
         written = writer.write_message(msg)
         expected = bytes([0, 1, 0, 0, 1, 42])
         self.assertEqual(written, expected)
@@ -126,7 +126,7 @@ class TestMessageWriter(unittest.TestCase):
         """
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
-        bad = {"u": {"_d": 5}}
+        bad = {"u": {UNION_DISCRIMINATOR_PROPERTY_KEY: 5}}
         with self.assertRaises(ValueError):
             writer.write_message(bad)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- add `UNION_DISCRIMINATOR_PROPERTY_KEY` constant with value `$discriminator`
- use shared constant for union discriminators in Python message reader and writer
- update tests to reference the constant

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests -q`
- `yarn parser:build`
- `yarn serde:test`


------
https://chatgpt.com/codex/tasks/task_e_688f637e2c888330b60dcd3f8cabe0ea