### PR TITLE
Add IDL processing helpers to Python parser

### DIFF
--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -9,6 +9,17 @@ from .parse import (
     Union,
     UnionCase,
 )
+from .process import (
+    IDLMessageDefinitionField,
+    IDLStructDefinition,
+    IDLModuleDefinition,
+    IDLUnionDefinition,
+    Case,
+    IDLMessageDefinition,
+    build_map,
+    to_idl_message_definitions,
+    parse_idl_message_definitions,
+)
 
 __all__ = [
     "parse_idl",
@@ -20,4 +31,13 @@ __all__ = [
     "Typedef",
     "Union",
     "UnionCase",
+    "IDLMessageDefinitionField",
+    "IDLStructDefinition",
+    "IDLModuleDefinition",
+    "IDLUnionDefinition",
+    "Case",
+    "IDLMessageDefinition",
+    "build_map",
+    "to_idl_message_definitions",
+    "parse_idl_message_definitions",
 ]

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+from .parse import (
+    Constant,
+    Enum,
+    Field,
+    Module,
+    Struct,
+    Typedef,
+    Union as IDLUnion,
+    UnionCase,
+)
+
+# ---------------------------------------------------------------------------
+# Message definition dataclasses -------------------------------------------------
+
+
+@dataclass
+class IDLMessageDefinitionField:
+    """Flattened field definition used by serialization code."""
+
+    name: str
+    type: str
+    isComplex: bool
+    annotations: Optional[Dict[str, Any]] = None
+    arrayLengths: Optional[List[int]] = None
+    arrayUpperBound: Optional[int] = None
+    upperBound: Optional[int] = None
+    isArray: Optional[bool] = None
+    enumType: Optional[str] = None
+    defaultValue: Optional[Any] = None
+    isConstant: bool = False
+    value: Optional[Any] = None
+    valueText: Optional[str] = None
+
+
+@dataclass
+class Case:
+    predicates: List[Union[int, bool]]
+    type: IDLMessageDefinitionField
+
+
+@dataclass
+class IDLStructDefinition:
+    name: str
+    definitions: List[IDLMessageDefinitionField]
+    aggregatedKind: str = "struct"
+    annotations: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class IDLModuleDefinition:
+    name: str
+    definitions: List[IDLMessageDefinitionField]
+    aggregatedKind: str = "module"
+    annotations: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class IDLUnionDefinition:
+    name: str
+    switchType: str
+    cases: List[Case]
+    aggregatedKind: str = "union"
+    defaultCase: Optional[IDLMessageDefinitionField] = None
+    annotations: Optional[Dict[str, Any]] = None
+
+
+IDLMessageDefinition = Union[IDLStructDefinition, IDLModuleDefinition, IDLUnionDefinition]
+
+# ---------------------------------------------------------------------------
+# Map building -------------------------------------------------------------------
+
+
+Definition = Union[Struct, Module, Constant, Enum, Typedef, IDLUnion]
+
+
+def build_map(definitions: Iterable[Definition]) -> "OrderedDict[str, Definition]":
+    """Traverse parsed nodes and return a map of fully scoped names to nodes."""
+
+    idl_map: "OrderedDict[str, Definition]" = OrderedDict()
+
+    def traverse(defn: Definition, scope: List[str]) -> None:
+        if isinstance(defn, Module):
+            for sub in defn.definitions:
+                traverse(sub, [*scope, defn.name])
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+        elif isinstance(defn, Enum):
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+            for enumerator in defn.enumerators:
+                scoped_enum = "::".join([*scope, defn.name, enumerator.name])
+                idl_map[scoped_enum] = enumerator
+        else:
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+
+    for definition in definitions:
+        traverse(definition, [])
+
+    return idl_map
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers -------------------------------------------------------------
+
+
+def _resolve_typedef(
+    type_name: str,
+    typedefs: Dict[str, Typedef],
+) -> tuple[str, List[int], bool, Optional[int], Optional[int]]:
+    """Resolve typedef chain returning final type and collected modifiers.
+
+    Returns a tuple of (type, array_lengths, is_sequence, sequence_bound,
+    string_upper_bound).
+    """
+
+    t = type_name
+    array_lengths: List[int] = []
+    is_sequence = False
+    seq_bound: Optional[int] = None
+    str_bound: Optional[int] = None
+    visited: set[str] = set()
+    while t in typedefs and t not in visited:
+        visited.add(t)
+        td = typedefs[t]
+        base_type = td.type
+        if isinstance(base_type, tuple):
+            if base_type[0] == "sequence":
+                is_sequence = True
+                seq_bound = base_type[2]
+                base_type = base_type[1]
+            else:
+                str_bound = base_type[1]
+                base_type = base_type[0]
+        t = base_type
+        if td.array_lengths:
+            array_lengths.extend(td.array_lengths)
+        if td.is_sequence:
+            is_sequence = True
+            if td.sequence_bound is not None:
+                seq_bound = td.sequence_bound
+        # string bounds are not currently represented on Typedef in parse.py
+    return t, array_lengths, is_sequence, seq_bound, str_bound
+
+
+def _convert_constant(
+    const: Constant,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> IDLMessageDefinitionField:
+    t, _arr, _is_seq, _seq_bound, _str_bound = _resolve_typedef(const.type, typedefs)
+    enum_type = None
+    is_complex = False
+    ref = idl_map.get(t)
+    if isinstance(ref, Enum):
+        enum_type = t
+        t = "uint32"
+    elif isinstance(ref, (Struct, IDLUnion)):
+        is_complex = True
+    return IDLMessageDefinitionField(
+        name=const.name,
+        type=t,
+        isComplex=is_complex,
+        enumType=enum_type,
+        isConstant=True,
+        value=const.value,
+        annotations=const.annotations or None,
+    )
+
+
+def _convert_field(
+    field: Field,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> IDLMessageDefinitionField:
+    t, td_arrays, td_is_seq, td_seq_bound, td_str_bound = _resolve_typedef(field.type, typedefs)
+    array_lengths = list(field.array_lengths)
+    if td_arrays:
+        array_lengths.extend(td_arrays)
+    is_sequence = field.is_sequence or td_is_seq
+    sequence_bound = field.sequence_bound if field.is_sequence else td_seq_bound
+    upper_bound = field.string_upper_bound if field.string_upper_bound is not None else td_str_bound
+
+    enum_type = None
+    is_complex = False
+    ref = idl_map.get(t)
+    if isinstance(ref, Enum):
+        enum_type = t
+        t = "uint32"
+    elif isinstance(ref, (Struct, IDLUnion)):
+        is_complex = True
+
+    annotations = field.annotations or None
+    default_value = None
+    if annotations and "default" in annotations:
+        default_value = annotations["default"]
+
+    is_array = bool(array_lengths) or is_sequence
+
+    return IDLMessageDefinitionField(
+        name=field.name,
+        type=t,
+        isComplex=is_complex,
+        annotations=annotations,
+        arrayLengths=array_lengths or None,
+        arrayUpperBound=sequence_bound if is_sequence else None,
+        upperBound=upper_bound,
+        isArray=is_array if is_array else None,
+        enumType=enum_type,
+        defaultValue=default_value,
+    )
+
+
+def _convert_union(
+    name: str,
+    union: IDLUnion,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> IDLUnionDefinition:
+    switch_type, _arr, _is_seq, _seq_bound, _str_bound = _resolve_typedef(
+        union.switch_type, typedefs
+    )
+    ref = idl_map.get(switch_type)
+    if isinstance(ref, Enum):
+        switch_type = "uint32"
+
+    cases: List[Case] = []
+    for case in union.cases:
+        field_def = _convert_field(case.field, typedefs, idl_map)
+        predicates = [p for p in case.predicates]  # already resolved values
+        cases.append(Case(predicates=predicates, type=field_def))
+
+    default_case = None
+    if union.default is not None:
+        default_case = _convert_field(union.default, typedefs, idl_map)
+
+    return IDLUnionDefinition(
+        name=name,
+        switchType=switch_type,
+        cases=cases,
+        defaultCase=default_case,
+        annotations=union.annotations or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API ---------------------------------------------------------------------
+
+
+def to_idl_message_definitions(
+    idl_map: "OrderedDict[str, Definition]",
+) -> List[IDLMessageDefinition]:
+    """Convert map entries into flattened message definitions."""
+
+    typedefs: Dict[str, Typedef] = {
+        name: node for name, node in idl_map.items() if isinstance(node, Typedef)
+    }
+
+    message_definitions: List[IDLMessageDefinition] = []
+    top_level_consts: List[IDLMessageDefinitionField] = []
+
+    for scoped_name, node in idl_map.items():
+        if isinstance(node, Struct):
+            fields = [_convert_field(f, typedefs, idl_map) for f in node.fields]
+            message_definitions.append(
+                IDLStructDefinition(
+                    name=scoped_name,
+                    definitions=fields,
+                    annotations=node.annotations or None,
+                )
+            )
+        elif isinstance(node, Module):
+            const_fields = [
+                _convert_constant(d, typedefs, idl_map)
+                for d in node.definitions
+                if isinstance(d, Constant)
+            ]
+            if const_fields:
+                message_definitions.append(
+                    IDLModuleDefinition(name=scoped_name, definitions=const_fields)
+                )
+        elif isinstance(node, Constant):
+            if "::" not in scoped_name:
+                top_level_consts.append(_convert_constant(node, typedefs, idl_map))
+        elif isinstance(node, Enum):
+            const_fields = [
+                _convert_constant(e, typedefs, idl_map) for e in node.enumerators
+            ]
+            message_definitions.append(
+                IDLModuleDefinition(name=scoped_name, definitions=const_fields)
+            )
+        elif isinstance(node, IDLUnion):
+            message_definitions.append(
+                _convert_union(scoped_name, node, typedefs, idl_map)
+            )
+        # Typedefs are only used for resolution; they do not produce output.
+
+    if top_level_consts:
+        message_definitions.append(
+            IDLModuleDefinition(name="", definitions=top_level_consts)
+        )
+
+    return message_definitions
+
+
+def parse_idl_message_definitions(source: str) -> List[IDLMessageDefinition]:
+    """Parse IDL text and return flattened message definitions."""
+
+    from .parse import parse_idl
+
+    parsed = parse_idl(source)
+    idl_map = build_map(parsed)
+    return to_idl_message_definitions(idl_map)
+
+
+__all__ = [
+    "IDLMessageDefinitionField",
+    "IDLStructDefinition",
+    "IDLModuleDefinition",
+    "IDLUnionDefinition",
+    "Case",
+    "IDLMessageDefinition",
+    "build_map",
+    "to_idl_message_definitions",
+    "parse_idl_message_definitions",
+]

--- a/python_omgidl/tests/test_process.py
+++ b/python_omgidl/tests/test_process.py
@@ -1,0 +1,84 @@
+import unittest
+
+from omgidl_parser import (
+    parse_idl_message_definitions,
+    IDLStructDefinition,
+    IDLModuleDefinition,
+    IDLUnionDefinition,
+)
+
+
+class TestProcess(unittest.TestCase):
+    def test_parse_idl_message_definitions(self) -> None:
+        schema = """
+        const long CONST_TOP = 42;
+
+        enum Color {
+            RED,
+            GREEN
+        };
+
+        module outer {
+            const short A = 1;
+            struct Inner { int32 value; };
+        };
+
+        typedef long MyLong;
+
+        struct Holder {
+            MyLong a;
+            Color color;
+            outer::Inner inner;
+        };
+
+        union MyUnion switch (Color) {
+            case Color::RED: long a;
+            default: outer::Inner b;
+        };
+        """
+        defs = parse_idl_message_definitions(schema)
+        by_name = {d.name: d for d in defs}
+
+        inner = by_name["outer::Inner"]
+        self.assertIsInstance(inner, IDLStructDefinition)
+        self.assertEqual(inner.aggregatedKind, "struct")
+        self.assertEqual(len(inner.definitions), 1)
+        self.assertEqual(inner.definitions[0].name, "value")
+        self.assertEqual(inner.definitions[0].type, "int32")
+
+        outer_mod = by_name["outer"]
+        self.assertIsInstance(outer_mod, IDLModuleDefinition)
+        self.assertEqual(len(outer_mod.definitions), 1)
+        self.assertEqual(outer_mod.definitions[0].name, "A")
+        self.assertEqual(outer_mod.definitions[0].value, 1)
+
+        color_mod = by_name["Color"]
+        self.assertIsInstance(color_mod, IDLModuleDefinition)
+        self.assertEqual({f.name: f.value for f in color_mod.definitions}, {"RED": 0, "GREEN": 1})
+
+        holder = by_name["Holder"]
+        self.assertIsInstance(holder, IDLStructDefinition)
+        self.assertEqual([f.name for f in holder.definitions], ["a", "color", "inner"])
+        self.assertEqual(holder.definitions[0].type, "int32")
+        self.assertEqual(holder.definitions[1].type, "uint32")
+        self.assertEqual(holder.definitions[1].enumType, "Color")
+        self.assertTrue(holder.definitions[2].isComplex)
+        self.assertEqual(holder.definitions[2].type, "outer::Inner")
+
+        union_def = by_name["MyUnion"]
+        self.assertIsInstance(union_def, IDLUnionDefinition)
+        self.assertEqual(union_def.switchType, "uint32")
+        self.assertEqual(len(union_def.cases), 1)
+        self.assertEqual(union_def.cases[0].predicates, [0])
+        self.assertEqual(union_def.cases[0].type.type, "int32")
+        self.assertIsNotNone(union_def.defaultCase)
+        self.assertEqual(union_def.defaultCase.type, "outer::Inner")
+
+        top_module = by_name[""]
+        self.assertIsInstance(top_module, IDLModuleDefinition)
+        self.assertEqual(top_module.definitions[0].name, "CONST_TOP")
+        self.assertEqual(top_module.definitions[0].value, 42)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python implementation for building IDL node map and generating IDL message definitions
- export new helpers and types from omgidl_parser package
- test IDL message definition parsing across constants, enums, structs and unions

## Testing
- `PYTHONPATH=python_omgidl pytest -q`
- `yarn workspace @foxglove/omgidl-parser test`
- `yarn test` *(fails: Cannot find module '@foxglove/omgidl-parser' in serialization tests)*

------
https://chatgpt.com/codex/tasks/task_e_688f6435e72c83308a9f208faeb6b058