### PR TITLE
Add header utilities and optional field handling to serializer

### DIFF
--- a/python_omgidl/omgidl_serialization/headers.py
+++ b/python_omgidl/omgidl_serialization/headers.py
@@ -1,0 +1,29 @@
+import struct
+from typing import Tuple
+
+
+def read_delimiter_header(view: memoryview, offset: int, fmt_prefix: str) -> Tuple[int, int]:
+    """Read a CDR2 delimiter header returning length and new offset."""
+    length = struct.unpack_from(fmt_prefix + "I", view, offset)[0]
+    return length, offset + 4
+
+
+def write_delimiter_header(buffer: bytearray, offset: int, length: int, fmt_prefix: str) -> int:
+    struct.pack_into(fmt_prefix + "I", buffer, offset, length)
+    return offset + 4
+
+
+def read_member_header(view: memoryview, offset: int, fmt_prefix: str) -> Tuple[int, int, int]:
+    """Return (field_id, size, new_offset)."""
+    field_id, size = struct.unpack_from(fmt_prefix + "HH", view, offset)
+    return field_id, size, offset + 4
+
+
+def write_member_header(buffer: bytearray, offset: int, field_id: int, size: int, fmt_prefix: str) -> int:
+    struct.pack_into(fmt_prefix + "HH", buffer, offset, field_id, size)
+    return offset + 4
+
+
+def write_sentinel_header(buffer: bytearray, offset: int, fmt_prefix: str) -> int:
+    struct.pack_into(fmt_prefix + "I", buffer, offset, 0)
+    return offset + 4

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -177,6 +177,37 @@ class TestMessageReader(unittest.TestCase):
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
 
+    def test_appendable_delimiter_roundtrip(self) -> None:
+        schema = """
+        @appendable
+        struct A {
+            int32 num;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"num": 5}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, msg)
+
+    def test_optional_field_default(self) -> None:
+        schema = """
+        @mutable
+        struct A {
+            @id(1) int32 num;
+            @id(2) @optional @default(3) int32 opt;
+        };
+        """
+        defs = parse_idl(schema)
+        writer = MessageWriter("A", defs)
+        reader = MessageReader("A", defs)
+        msg = {"num": 5}
+        buf = writer.write_message(msg)
+        decoded = reader.read_message(buf)
+        self.assertEqual(decoded, {"num": 5, "opt": 3})
+
     def test_roundtrip_sequence_of_structs(self) -> None:
         inner = Struct(name="Inner", fields=[Field(name="num", type="int32")])
         outer = Struct(name="Outer", fields=[Field(name="inners", type="Inner", is_sequence=True)])


### PR DESCRIPTION
## Summary
- add delimiter, member and sentinel header helpers
- track field options and defaults for CDR2 headers
- read and write new headers, supporting optional fields with defaults
- cover appendable/mutable structs and optional fields in tests

## Testing
- `PYTHONPATH=python_omgidl python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6914953883308fc263814d91a396