### PR TITLE
Handle unions and enums in ros2idl parser

### DIFF
--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -14,8 +14,7 @@ from omgidl_parser.parse import (
     Typedef as IDLTypedef,
     Union as IDLUnion,
 )
-
-from omgidl_serialization.constants import UNION_DISCRIMINATOR_PROPERTY_KEY
+from omgidl_parser.process import build_map
 
 
 @dataclass
@@ -48,9 +47,10 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
     idl_conformed = ROS2IDL_HEADER.sub("", message_definition)
     parsed = parse_idl(idl_conformed)
     typedefs = _collect_typedefs(parsed, [])
+    idl_map = build_map(parsed)
     message_defs: List[MessageDefinition] = []
     for definition in parsed:
-        message_defs.extend(_process_definition(definition, [], typedefs))
+        message_defs.extend(_process_definition(definition, [], typedefs, idl_map))
 
     for msg in message_defs:
         if msg.name is not None:
@@ -70,23 +70,14 @@ def _process_definition(
     defn: IDLStruct | IDLModule | IDLConstant | IDLEnum | IDLUnion | IDLTypedef,
     scope: List[str],
     typedefs: dict[str, IDLTypedef],
+    idl_map,
 ) -> List[MessageDefinition]:
     results: List[MessageDefinition] = []
     if isinstance(defn, IDLStruct):
-        fields = [_convert_field(f, typedefs) for f in defn.fields]
+        fields = [_convert_field(f, typedefs, idl_map, scope) for f in defn.fields]
         results.append(MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields))
     elif isinstance(defn, IDLUnion):
-        switch_type = _resolve_type(defn.switch_type, typedefs)
-        fields = [
-            MessageDefinitionField(
-                type=switch_type, name=UNION_DISCRIMINATOR_PROPERTY_KEY
-            )
-        ]
-        for case in defn.cases:
-            fields.append(_convert_field(case.field, typedefs))
-        if defn.default:
-            fields.append(_convert_field(defn.default, typedefs))
-        results.append(MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields))
+        raise ValueError("Unions are not supported in MessageDefinition type")
     elif isinstance(defn, IDLModule):
         const_fields = [
             _convert_constant(c, typedefs)
@@ -98,37 +89,71 @@ def _process_definition(
                 MessageDefinition(name="/".join([*scope, defn.name]), definitions=const_fields)
             )
         for sub in defn.definitions:
-            if isinstance(sub, (IDLModule, IDLStruct, IDLUnion)):
-                results.extend(_process_definition(sub, [*scope, defn.name], typedefs))
+            if isinstance(sub, (IDLModule, IDLStruct, IDLUnion, IDLEnum)):
+                results.extend(
+                    _process_definition(sub, [*scope, defn.name], typedefs, idl_map)
+                )
+    elif isinstance(defn, IDLEnum):
+        fields = [_convert_constant(e, typedefs) for e in defn.enumerators]
+        results.append(
+            MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields)
+        )
     elif isinstance(defn, IDLConstant):
         results.append(
             MessageDefinition(
                 name="/".join(scope), definitions=[_convert_constant(defn, typedefs)]
             )
         )
-    # IDLEnum and IDLTypedef do not directly produce MessageDefinitions here
+    # IDLTypedef does not directly produce MessageDefinitions here
     return results
 
 
-def _convert_field(field: IDLField, typedefs: dict[str, IDLTypedef]) -> MessageDefinitionField:
+def _convert_field(
+    field: IDLField,
+    typedefs: dict[str, IDLTypedef],
+    idl_map,
+    scope: List[str],
+) -> MessageDefinitionField:
     t = field.type
     array_lengths = list(field.array_lengths)
     is_sequence = field.is_sequence
     seq_bound = field.sequence_bound
     visited: set[str] = set()
-    while t in typedefs and t not in visited:
-        visited.add(t)
-        td = typedefs[t]
+    while True:
+        key = t if t in typedefs else "::".join([*scope, t])
+        if key in visited or key not in typedefs:
+            break
+        visited.add(key)
+        td = typedefs[key]
         t = td.type
-        if td.array_lengths and not array_lengths and not is_sequence:
-            array_lengths = list(td.array_lengths)
+        if td.array_lengths:
+            array_lengths.extend(td.array_lengths)
         if td.is_sequence:
             is_sequence = True
             if td.sequence_bound is not None:
                 seq_bound = td.sequence_bound
+    if len(array_lengths) > 1:
+        raise ValueError(
+            "Multi-dimensional arrays are not supported in MessageDefinition type"
+        )
+    enum_type: Optional[str] = None
+    is_complex = False
+    ref = idl_map.get(t)
+    if ref is None and "::" not in t:
+        scoped = "::".join([*scope, t])
+        ref = idl_map.get(scoped)
+        if ref is not None:
+            t = scoped
+    if isinstance(ref, IDLEnum):
+        enum_type = t
+        t = "uint32"
+    elif isinstance(ref, (IDLStruct, IDLUnion)):
+        is_complex = True
     return MessageDefinitionField(
         type=t,
         name=field.name,
+        isComplex=is_complex,
+        enumType=enum_type,
         isArray=bool(array_lengths) or is_sequence,
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=seq_bound if is_sequence else None,

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -57,6 +57,8 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
             msg.name = _normalize_name(msg.name)
         for field in msg.definitions:
             field.type = _normalize_name(field.type)
+            if field.enumType:
+                field.enumType = _normalize_name(field.enumType)
 
         if msg.name in ("builtin_interfaces/msg/Time", "builtin_interfaces/msg/Duration"):
             for field in msg.definitions:
@@ -145,7 +147,7 @@ def _convert_field(
         if ref is not None:
             t = scoped
     if isinstance(ref, IDLEnum):
-        enum_type = t
+        enum_type = _normalize_name(t)
         t = "uint32"
     elif isinstance(ref, (IDLStruct, IDLUnion)):
         is_complex = True

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -210,6 +210,42 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_scoped_enum_reference(self):
+        schema = """
+        module colors {
+          enum Palette {
+            RED,
+            GREEN
+          };
+        };
+        struct Pixel { colors::Palette tone; };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="colors/Palette",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="uint32", name="RED", isConstant=True, value=0, valueText="0"
+                        ),
+                        MessageDefinitionField(
+                            type="uint32", name="GREEN", isConstant=True, value=1, valueText="1"
+                        ),
+                    ],
+                ),
+                MessageDefinition(
+                    name="Pixel",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="uint32", name="tone", enumType="colors/Palette"
+                        )
+                    ],
+                ),
+            ],
+        )
+
     def test_union_definition_not_supported(self):
         schema = """
         union MyUnion switch (uint8) {

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -1,7 +1,6 @@
 import unittest
 
 from ros2idl_parser import parse_ros2idl, MessageDefinition, MessageDefinitionField
-from omgidl_serialization import UNION_DISCRIMINATOR_PROPERTY_KEY
 
 
 class TestParseRos2idl(unittest.TestCase):
@@ -139,37 +138,93 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
-    def test_union_definition(self):
+    def test_struct_field_is_complex(self):
         schema = """
-        typedef long MyLong;
-        union MyUnion switch (uint8) {
-          case 0: MyLong as_long;
-          case 1: string as_string;
+        module rosidl_parser {
+          module msg {
+            struct MyMessage {
+              geometry::msg::Point single_point;
+            };
+          };
         };
-        struct Container { MyUnion value; };
+        module geometry {
+          module msg {
+            struct Point { float x; };
+          };
+        };
         """
         types = parse_ros2idl(schema)
         self.assertEqual(
             types,
             [
                 MessageDefinition(
-                    name="MyUnion",
+                    name="rosidl_parser/msg/MyMessage",
                     definitions=[
                         MessageDefinitionField(
-                            type="uint8", name=UNION_DISCRIMINATOR_PROPERTY_KEY
-                        ),
-                        MessageDefinitionField(type="int32", name="as_long"),
-                        MessageDefinitionField(type="string", name="as_string"),
+                            type="geometry/msg/Point", name="single_point", isComplex=True
+                        )
                     ],
                 ),
                 MessageDefinition(
-                    name="Container",
+                    name="geometry/msg/Point",
+                    definitions=[MessageDefinitionField(type="float32", name="x")],
+                ),
+            ],
+        )
+
+    def test_enum_reference(self):
+        schema = """
+        enum COLORS {
+          RED,
+          GREEN,
+          BLUE
+        };
+        struct Line { COLORS color; };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="COLORS",
                     definitions=[
-                        MessageDefinitionField(type="MyUnion", name="value")
+                        MessageDefinitionField(
+                            type="uint32", name="RED", isConstant=True, value=0, valueText="0"
+                        ),
+                        MessageDefinitionField(
+                            type="uint32", name="GREEN", isConstant=True, value=1, valueText="1"
+                        ),
+                        MessageDefinitionField(
+                            type="uint32", name="BLUE", isConstant=True, value=2, valueText="2"
+                        ),
+                    ],
+                ),
+                MessageDefinition(
+                    name="Line",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="uint32", name="color", enumType="COLORS"
+                        )
                     ],
                 ),
             ],
         )
+
+    def test_union_definition_not_supported(self):
+        schema = """
+        union MyUnion switch (uint8) {
+          case 0: string as_string;
+        };
+        """
+        with self.assertRaises(ValueError):
+            parse_ros2idl(schema)
+
+    def test_multi_dimensional_array_not_supported(self):
+        schema = """
+        struct MultiArray { int32 data[3][5]; };
+        """
+        with self.assertRaises(ValueError):
+            parse_ros2idl(schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- mark complex and enum fields when converting ROS2 IDL definitions
- reject union definitions and multi-dimensional arrays
- add test coverage for enums, complex fields, and unsupported constructs

## Testing
- `PYTHONPATH=python_omgidl pytest python_omgidl/tests/test_parse_ros2idl.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd4894e888330b9dd649b2ae39c9d