### PR TITLE
Default to appendable extensibility

### DIFF
--- a/python_omgidl/omgidl_serialization/deserialization_info_cache.py
+++ b/python_omgidl/omgidl_serialization/deserialization_info_cache.py
@@ -200,7 +200,8 @@ def _get_header_needs(definition: Struct | IDLUnion) -> tuple[bool, bool]:
         return (True, True)
     if "appendable" in annotations:
         return (True, False)
-    return (False, False)
+    # Default extensibility is appendable when unspecified
+    return (True, False)
 
 
 def _find_struct(defs: List[Struct | Module], name: str) -> Optional[Struct]:

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -177,9 +177,8 @@ class TestMessageReader(unittest.TestCase):
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
 
-    def test_appendable_delimiter_roundtrip(self) -> None:
+    def test_default_delimiter_roundtrip(self) -> None:
         schema = """
-        @appendable
         struct A {
             int32 num;
         };

--- a/python_omgidl/tests/test_serialization.py
+++ b/python_omgidl/tests/test_serialization.py
@@ -16,7 +16,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"num": 5, "flag": 7}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 7])
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 7])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -31,7 +31,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"flag": 7}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 7])
+        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 7])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -45,7 +45,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"data": [1, 2, 3, 4]}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 1, 2, 3, 4])
+        expected = bytes([0, 1, 0, 0, 4, 0, 0, 0, 1, 2, 3, 4])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -59,7 +59,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"data": [[1, 2, 3], [4, 5, 6]]}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 1, 2, 3, 4, 5, 6])
+        expected = bytes([0, 1, 0, 0, 6, 0, 0, 0, 1, 2, 3, 4, 5, 6])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -73,7 +73,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"name": "hi"}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 3, 0, 0, 0, 104, 105, 0])
+        expected = bytes([0, 1, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 104, 105, 0])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -86,7 +86,7 @@ class TestMessageWriter(unittest.TestCase):
         defs = parse_idl(schema)
         writer = MessageWriter("A", defs)
         ok = {"name": "hello"}
-        expected = bytes([0, 1, 0, 0, 6, 0, 0, 0, 104, 101, 108, 108, 111, 0])
+        expected = bytes([0, 1, 0, 0, 10, 0, 0, 0, 6, 0, 0, 0, 104, 101, 108, 108, 111, 0])
         written = writer.write_message(ok)
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(ok), len(expected))
@@ -110,7 +110,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("A", defs)
         msg = {"u": {UNION_DISCRIMINATOR_PROPERTY_KEY: 1, "b": 42}}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 1, 42])
+        expected = bytes([0, 1, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, 1, 42])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -139,7 +139,7 @@ class TestMessageWriter(unittest.TestCase):
         writer = MessageWriter("Outer", defs)
         msg = {"inner": {"num": 5}}
         written = writer.write_message(msg)
-        expected = bytes([0, 1, 0, 0, 5, 0, 0, 0])
+        expected = bytes([0, 1, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0])
         self.assertEqual(written, expected)
         self.assertEqual(writer.calculate_byte_size(msg), len(expected))
 
@@ -150,6 +150,7 @@ class TestMessageWriter(unittest.TestCase):
         written = writer.write_message(msg)
         expected = bytes([
             0, 1, 0, 0,
+            12, 0, 0, 0,
             2, 0, 0, 0,
             3, 0, 0, 0,
             7, 0, 0, 0,
@@ -166,8 +167,11 @@ class TestMessageWriter(unittest.TestCase):
         written = writer.write_message(msg)
         expected = bytes([
             0, 1, 0, 0,
+            20, 0, 0, 0,
             2, 0, 0, 0,
+            4, 0, 0, 0,
             1, 0, 0, 0,
+            4, 0, 0, 0,
             2, 0, 0, 0,
         ])
         self.assertEqual(written, expected)
@@ -185,6 +189,7 @@ class TestMessageWriter(unittest.TestCase):
         written = writer.write_message(msg)
         expected = bytes([
             0, 1, 0, 0,
+            12, 0, 0, 0,
             2, 0, 0, 0,
             3, 0, 0, 0,
             7, 0, 0, 0,
@@ -197,9 +202,8 @@ class TestMessageWriter(unittest.TestCase):
         with self.assertRaises(ValueError):
             writer.calculate_byte_size(over)
 
-    def test_appendable_struct_delimiter(self) -> None:
+    def test_default_appendable_struct_delimiter(self) -> None:
         schema = """
-        @appendable
         struct A {
             int32 num;
         };


### PR DESCRIPTION
## Summary
- Default to appendable extensibility without requiring annotations
- Remove unsupported `@final` usage and update serialization tests accordingly

## Testing
- `PYTHONPATH=python_omgidl pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd484196083309276f5440ae1e5aa