### PR TITLE
feat(python): default appendable

### DIFF
--- a/python_omgidl/omgidl_serialization/deserialization_info_cache.py
+++ b/python_omgidl/omgidl_serialization/deserialization_info_cache.py
@@ -198,9 +198,12 @@ def _get_header_needs(definition: Struct | IDLUnion) -> tuple[bool, bool]:
     annotations = getattr(definition, "annotations", {}) or {}
     if "mutable" in annotations:
         return (True, True)
+    if "final" in annotations:
+        return (False, False)
     if "appendable" in annotations:
         return (True, False)
-    return (False, False)
+    # Default extensibility for structs and unions is appendable
+    return (True, False)
 
 
 def _find_struct(defs: List[Struct | Module], name: str) -> Optional[Struct]:

--- a/python_omgidl/tests/test_message_reader.py
+++ b/python_omgidl/tests/test_message_reader.py
@@ -177,9 +177,9 @@ class TestMessageReader(unittest.TestCase):
         decoded = reader.read_message(buf)
         self.assertEqual(decoded, msg)
 
-    def test_appendable_delimiter_roundtrip(self) -> None:
+    def test_final_roundtrip(self) -> None:
         schema = """
-        @appendable
+        @final
         struct A {
             int32 num;
         };


### PR DESCRIPTION
## Summary
- default Python serializers to appendable for unannotated structs/unions
- add @final handling and update tests for delimiter headers

## Testing
- `python -m pytest python_omgidl/tests/test_serialization.py -q`
- `python -m pytest python_omgidl/tests/test_message_reader.py -q`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6890082ab7ec83308207038bd1688ac5