### PR TITLE
Add pre-commit configuration for Python linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "isort",
     "flake8",
     "flake8-pyproject",
+    "pre-commit",
 ]
 
 [tool.isort]

--- a/python_omgidl/omgidl_serialization/message_writer.py
+++ b/python_omgidl/omgidl_serialization/message_writer.py
@@ -414,9 +414,9 @@ class MessageWriter:
                         offset += 4
                         buffer[offset : offset + len(encoded)] = encoded
                         offset += len(encoded)
-                        buffer[offset : offset + (1 if t == "string" else 2)] = (
-                            b"\x00" * (1 if t == "string" else 2)
-                        )
+                        buffer[
+                            offset : offset + (1 if t == "string" else 2)
+                        ] = b"\x00" * (1 if t == "string" else 2)
                         offset += 1 if t == "string" else 2
                 elif t in PRIMITIVE_SIZES:
                     size = _primitive_size(t)


### PR DESCRIPTION
## Summary
- add pre-commit config to run black, isort, and flake8
- include pre-commit in dev dependencies
- reformat message_writer to satisfy black

## Testing
- `pre-commit run --files $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'omgidl_parser')*

------
https://chatgpt.com/codex/tasks/task_e_6891425bb3cc83308905f9c496980cd5