### PR TITLE
feat: add Python message definition package

### DIFF
--- a/python_omgidl/foxglove_message_definition/__init__.py
+++ b/python_omgidl/foxglove_message_definition/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import List, Optional, Sequence, Union
+
+# Type aliases matching the TypeScript package
+ConstantValue = Optional[Union[str, int, float, bool]]
+DefaultValue = Optional[
+    Union[
+        str,
+        int,
+        float,
+        bool,
+        Sequence[str],
+        Sequence[int],
+        Sequence[float],
+        Sequence[bool],
+    ]
+]
+
+
+@dataclass
+class MessageDefinitionField:
+    """A single field in a message definition."""
+
+    type: str
+    name: str
+    isComplex: bool = False
+    enumType: Optional[str] = None
+    isArray: bool = False
+    arrayLength: Optional[int] = None
+    isConstant: bool = False
+    value: ConstantValue = None
+    valueText: Optional[str] = None
+    upperBound: Optional[int] = None
+    arrayUpperBound: Optional[int] = None
+    defaultValue: DefaultValue = None
+
+
+@dataclass
+class MessageDefinition:
+    """A message definition containing an optional name and a list of fields."""
+
+    name: Optional[str] = None
+    definitions: List[MessageDefinitionField] = dataclass_field(default_factory=list)
+
+
+__all__ = [
+    "ConstantValue",
+    "DefaultValue",
+    "MessageDefinition",
+    "MessageDefinitionField",
+]

--- a/python_omgidl/foxglove_message_definition/__init__.py
+++ b/python_omgidl/foxglove_message_definition/__init__.py
@@ -5,18 +5,17 @@ from dataclasses import field as dataclass_field
 from typing import List, Optional, Sequence, Union
 
 # Type aliases matching the TypeScript package
-ConstantValue = Optional[Union[str, int, float, bool]]
-DefaultValue = Optional[
-    Union[
-        str,
-        int,
-        float,
-        bool,
-        Sequence[str],
-        Sequence[int],
-        Sequence[float],
-        Sequence[bool],
-    ]
+ConstantValue = Union[str, int, float, bool, None]
+DefaultValue = Union[
+    str,
+    int,
+    float,
+    bool,
+    Sequence[str],
+    Sequence[int],
+    Sequence[float],
+    Sequence[bool],
+    None,
 ]
 
 
@@ -26,11 +25,11 @@ class MessageDefinitionField:
 
     type: str
     name: str
-    isComplex: bool = False
+    isComplex: Optional[bool] = None
     enumType: Optional[str] = None
-    isArray: bool = False
+    isArray: Optional[bool] = None
     arrayLength: Optional[int] = None
-    isConstant: bool = False
+    isConstant: Optional[bool] = None
     value: ConstantValue = None
     valueText: Optional[str] = None
     upperBound: Optional[int] = None

--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -1,3 +1,5 @@
+from foxglove_message_definition import MessageDefinitionField
+
 from .parse import (
     Constant,
     Enum,
@@ -12,7 +14,6 @@ from .parse import (
 from .process import (
     Case,
     IDLMessageDefinition,
-    IDLMessageDefinitionField,
     IDLModuleDefinition,
     IDLStructDefinition,
     IDLUnionDefinition,
@@ -31,7 +32,7 @@ __all__ = [
     "Typedef",
     "Union",
     "UnionCase",
-    "IDLMessageDefinitionField",
+    "MessageDefinitionField",
     "IDLStructDefinition",
     "IDLModuleDefinition",
     "IDLUnionDefinition",

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -4,6 +4,8 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+from foxglove_message_definition import MessageDefinitionField
+
 from .parse import Constant, Enum, Field, Module, Struct, Typedef
 from .parse import Union as IDLUnion
 
@@ -12,34 +14,15 @@ from .parse import Union as IDLUnion
 
 
 @dataclass
-class IDLMessageDefinitionField:
-    """Flattened field definition used by serialization code."""
-
-    name: str
-    type: str
-    isComplex: bool
-    annotations: Optional[Dict[str, Any]] = None
-    arrayLengths: Optional[List[int]] = None
-    arrayUpperBound: Optional[int] = None
-    upperBound: Optional[int] = None
-    isArray: Optional[bool] = None
-    enumType: Optional[str] = None
-    defaultValue: Optional[Any] = None
-    isConstant: bool = False
-    value: Optional[Any] = None
-    valueText: Optional[str] = None
-
-
-@dataclass
 class Case:
     predicates: List[Union[int, bool]]
-    type: IDLMessageDefinitionField
+    type: MessageDefinitionField
 
 
 @dataclass
 class IDLStructDefinition:
     name: str
-    definitions: List[IDLMessageDefinitionField]
+    definitions: List[MessageDefinitionField]
     aggregatedKind: str = "struct"
     annotations: Optional[Dict[str, Any]] = None
 
@@ -47,7 +30,7 @@ class IDLStructDefinition:
 @dataclass
 class IDLModuleDefinition:
     name: str
-    definitions: List[IDLMessageDefinitionField]
+    definitions: List[MessageDefinitionField]
     aggregatedKind: str = "module"
     annotations: Optional[Dict[str, Any]] = None
 
@@ -58,7 +41,7 @@ class IDLUnionDefinition:
     switchType: str
     cases: List[Case]
     aggregatedKind: str = "union"
-    defaultCase: Optional[IDLMessageDefinitionField] = None
+    defaultCase: Optional[MessageDefinitionField] = None
     annotations: Optional[Dict[str, Any]] = None
 
 
@@ -164,7 +147,7 @@ def _convert_constant(
     const: Constant,
     typedefs: Dict[str, Typedef],
     idl_map: Dict[str, Definition],
-) -> IDLMessageDefinitionField:
+) -> MessageDefinitionField:
     t, _arr, _is_seq, _seq_bound, _str_bound = _resolve_typedef(const.type, typedefs)
     enum_type = None
     is_complex = False
@@ -174,14 +157,14 @@ def _convert_constant(
         t = "uint32"
     elif isinstance(ref, (Struct, IDLUnion)):
         is_complex = True
-    return IDLMessageDefinitionField(
+    return MessageDefinitionField(
         name=const.name,
         type=t,
         isComplex=is_complex,
         enumType=enum_type,
         isConstant=True,
         value=const.value,
-        annotations=const.annotations or None,
+        valueText=str(const.value),
     )
 
 
@@ -189,7 +172,7 @@ def _convert_field(
     field: Field,
     typedefs: Dict[str, Typedef],
     idl_map: Dict[str, Definition],
-) -> IDLMessageDefinitionField:
+) -> MessageDefinitionField:
     t, td_arrays, td_is_seq, td_seq_bound, td_str_bound = _resolve_typedef(
         field.type, typedefs
     )
@@ -230,16 +213,15 @@ def _convert_field(
 
     is_array = bool(array_lengths) or is_sequence
 
-    return IDLMessageDefinitionField(
-        name=field.name,
+    return MessageDefinitionField(
         type=t,
+        name=field.name,
         isComplex=is_complex,
-        annotations=annotations,
-        arrayLengths=array_lengths or None,
+        isArray=is_array,
+        arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=sequence_bound if is_sequence else None,
-        upperBound=upper_bound,
-        isArray=is_array if is_array else None,
         enumType=enum_type,
+        upperBound=upper_bound,
         defaultValue=default_value,
     )
 
@@ -290,7 +272,7 @@ def to_idl_message_definitions(
     }
 
     message_definitions: List[IDLMessageDefinition] = []
-    top_level_consts: List[IDLMessageDefinitionField] = []
+    top_level_consts: List[MessageDefinitionField] = []
 
     for scoped_name, node in idl_map.items():
         if isinstance(node, Struct):
@@ -347,7 +329,6 @@ def parse_idl_message_definitions(source: str) -> List[IDLMessageDefinition]:
 
 
 __all__ = [
-    "IDLMessageDefinitionField",
     "IDLStructDefinition",
     "IDLModuleDefinition",
     "IDLUnionDefinition",

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -160,7 +160,7 @@ def _convert_constant(
     return MessageDefinitionField(
         name=const.name,
         type=t,
-        isComplex=is_complex,
+        isComplex=True if is_complex else None,
         enumType=enum_type,
         isConstant=True,
         value=const.value,
@@ -216,8 +216,8 @@ def _convert_field(
     return MessageDefinitionField(
         type=t,
         name=field.name,
-        isComplex=is_complex,
-        isArray=is_array,
+        isComplex=True if is_complex else None,
+        isArray=True if is_array else None,
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=sequence_bound if is_sequence else None,
         enumType=enum_type,

--- a/python_omgidl/ros2idl_parser/__init__.py
+++ b/python_omgidl/ros2idl_parser/__init__.py
@@ -1,3 +1,5 @@
-from .parse import MessageDefinition, MessageDefinitionField, parse_ros2idl
+from foxglove_message_definition import MessageDefinition, MessageDefinitionField
+
+from .parse import parse_ros2idl
 
 __all__ = ["parse_ros2idl", "MessageDefinition", "MessageDefinitionField"]

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from dataclasses import field as dataclass_field
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 
+from foxglove_message_definition import MessageDefinition, MessageDefinitionField
 from omgidl_parser.parse import Constant as IDLConstant
 from omgidl_parser.parse import Enum as IDLEnum
 from omgidl_parser.parse import Field as IDLField
@@ -14,29 +13,6 @@ from omgidl_parser.parse import Typedef as IDLTypedef
 from omgidl_parser.parse import Union as IDLUnion
 from omgidl_parser.parse import parse_idl
 from omgidl_parser.process import build_map
-
-
-@dataclass
-class MessageDefinitionField:
-    type: str
-    name: str
-    isComplex: bool = False
-    enumType: Optional[str] = None
-    isArray: bool = False
-    arrayLength: Optional[int] = None
-    isConstant: bool = False
-    value: Optional[Union[str, int]] = None
-    valueText: Optional[str] = None
-    upperBound: Optional[int] = None
-    arrayUpperBound: Optional[int] = None
-    defaultValue: Optional[Any] = None
-
-
-@dataclass
-class MessageDefinition:
-    name: Optional[str]
-    definitions: List[MessageDefinitionField] = dataclass_field(default_factory=list)
-
 
 ROS2IDL_HEADER = re.compile(r"={80}\nIDL: [a-zA-Z][\w]*(?:\/[a-zA-Z][\w]*)*")
 

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -136,9 +136,9 @@ def _convert_field(
     return MessageDefinitionField(
         type=t,
         name=field.name,
-        isComplex=is_complex,
+        isComplex=True if is_complex else None,
         enumType=enum_type,
-        isArray=bool(array_lengths) or is_sequence,
+        isArray=True if (array_lengths or is_sequence) else None,
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=seq_bound if is_sequence else None,
     )

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -39,7 +39,6 @@ class TestParseRos2idl(unittest.TestCase):
                         MessageDefinitionField(
                             type="int32",
                             name="input_value",
-                            isArray=False,
                         )
                     ],
                 ),


### PR DESCRIPTION
## Summary
- create `foxglove_message_definition` package mirroring TypeScript message definition types
- refactor ROS2IDL and OMG IDL parsers to use shared message definition dataclasses

## Testing
- `pre-commit run --files python_omgidl/omgidl_parser/process.py python_omgidl/omgidl_parser/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a75bcfa08330923a516821ea7526