### PR TITLE
Refactor bool flags to avoid None values

### DIFF
--- a/python_omgidl/foxglove_message_definition/__init__.py
+++ b/python_omgidl/foxglove_message_definition/__init__.py
@@ -25,11 +25,11 @@ class MessageDefinitionField:
 
     type: str
     name: str
-    isComplex: Optional[bool] = None
+    isComplex: bool = False
     enumType: Optional[str] = None
-    isArray: Optional[bool] = None
+    isArray: bool = False
     arrayLength: Optional[int] = None
-    isConstant: Optional[bool] = None
+    isConstant: bool = False
     value: ConstantValue = None
     valueText: Optional[str] = None
     upperBound: Optional[int] = None

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -160,7 +160,7 @@ def _convert_constant(
     return MessageDefinitionField(
         name=const.name,
         type=t,
-        isComplex=True if is_complex else None,
+        isComplex=is_complex,
         enumType=enum_type,
         isConstant=True,
         value=const.value,
@@ -216,8 +216,8 @@ def _convert_field(
     return MessageDefinitionField(
         type=t,
         name=field.name,
-        isComplex=True if is_complex else None,
-        isArray=True if is_array else None,
+        isComplex=is_complex,
+        isArray=is_array,
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=sequence_bound if is_sequence else None,
         enumType=enum_type,

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -138,7 +138,7 @@ def _convert_field(
         name=field.name,
         isComplex=is_complex,
         enumType=enum_type,
-        isArray=bool(array_lengths or is_sequence),
+        isArray=array_lengths or is_sequence,
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=seq_bound if is_sequence else None,
     )

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -136,9 +136,9 @@ def _convert_field(
     return MessageDefinitionField(
         type=t,
         name=field.name,
-        isComplex=True if is_complex else None,
+        isComplex=is_complex,
         enumType=enum_type,
-        isArray=True if (array_lengths or is_sequence) else None,
+        isArray=bool(array_lengths or is_sequence),
         arrayLength=array_lengths[0] if array_lengths else None,
         arrayUpperBound=seq_bound if is_sequence else None,
     )


### PR DESCRIPTION
## Summary
- switch MessageDefinitionField boolean flags from Optional to plain bool defaults
- simplify field conversion helpers to assign booleans directly instead of using None

## Testing
- `pytest`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6891c47118a083309785bf3c753d81b9