### PR TITLE
Handle multiline strings in IDL parser

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -81,7 +81,7 @@ semicolon: ";"
 BOOL.2: /(?i)true|false/
 %import common.SIGNED_INT
 %import common.SIGNED_FLOAT
-%import common.ESCAPED_STRING -> STRING
+STRING: /"(?:[^"\\]|\\.)*"/
 %import common.WS
 
 COMMENT: /\/\/[^\n]*|\/\*[\s\S]*?\*\//
@@ -262,7 +262,8 @@ class _Transformer(Transformer):
         return int(token)
 
     def STRING(self, token):
-        return str(token)[1:-1]
+        value = str(token)[1:-1]
+        return bytes(value, "utf-8").decode("unicode_escape")
 
     def array(self, items):
         return [int(itm) for itm in items]

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -91,7 +91,34 @@ class TestParseIDL(unittest.TestCase):
                     annotations={
                         "verbatim": {
                             "language": "comment",
-                            "text": "line1\\nline2\\nline3",
+                            "text": """line1
+line2
+line3""",
+                        }
+                    },
+                )
+            ],
+        )
+
+    def test_annotation_single_multiline_string(self):
+        schema = """
+        @verbatim(language="comment", text=
+"line1
+line2
+line3")
+        struct A { uint8 val; };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Struct(
+                    name="A",
+                    fields=[Field(name="val", type="uint8")],
+                    annotations={
+                        "verbatim": {
+                            "language": "comment",
+                            "text": "line1\nline2\nline3",
                         }
                     },
                 )


### PR DESCRIPTION
## Summary
- allow multi-line string literals in IDL grammar
- decode escaped sequences when reading IDL strings
- test parsing of annotations that contain multi-line strings

## Testing
- `pre-commit run --files python_omgidl/omgidl_parser/parse.py python_omgidl/tests/test_parse.py`
- `python -m pytest python_omgidl/tests`
- `yarn test` *(fails: Couldn't find the node_modules state file - running an install might help)*

------
https://chatgpt.com/codex/tasks/task_e_689727fa8d008330b447cef40e5c813e