### PR TITLE
Fix nested enum type resolution and allow multiline strings

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 from typing import Union as TypingUnion
@@ -81,8 +82,7 @@ semicolon: ";"
 BOOL.2: /(?i)true|false/
 %import common.SIGNED_INT
 %import common.SIGNED_FLOAT
-%import common.ESCAPED_STRING
-STRING: ESCAPED_STRING
+STRING: /(?s)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/
 %import common.WS
 
 COMMENT: /\/\/[^\n]*|\/\*[\s\S]*?\*\//
@@ -465,7 +465,7 @@ class _Transformer(Transformer):
             scope: List[str],
         ):
             for d in defs:
-                if isinstance(d, (Struct, Union, Typedef)):
+                if isinstance(d, (Struct, Union, Typedef, Enum)):
                     full = "::".join([*scope, d.name])
                     named_types.add(full)
                 if isinstance(d, Module):
@@ -479,7 +479,7 @@ class _Transformer(Transformer):
             if f.type.startswith("::"):
                 f.type = f.type[2:]
                 return
-            if "::" in f.type:
+            if f.type in named_types:
                 return
             resolved = None
             for i in range(len(scope), -1, -1):

--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -82,6 +82,10 @@ semicolon: ";"
 BOOL.2: /(?i)true|false/
 %import common.SIGNED_INT
 %import common.SIGNED_FLOAT
+# STRING matches both double-quoted and single-quoted string literals, including escaped characters.
+# The (?s) flag enables dot-all mode so that '.' matches newlines, allowing multiline strings.
+# The pattern uses non-capturing groups to separately handle double-quoted and single-quoted strings.
+# Inside each, (?:\\.|[^"\\])* matches any sequence of escaped characters or any character except the quote or backslash.
 STRING: /(?s)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/
 %import common.WS
 

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -143,7 +143,7 @@ class TestParseRos2idl(unittest.TestCase):
                     MessageDefinitionField(
                         type="uint32",
                         name="error",
-                        enumType=("test_interfaces/msg/" "TestMessage_Enums/TestEnum"),
+                        enumType="test_interfaces/msg/TestMessage_Enums/TestEnum",
                     )
                 ],
             ),

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -121,6 +121,34 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_nested_enum_field(self):
+        schema = """
+        module test_interfaces {
+          module msg {
+            module TestMessage_Enums {
+              enum TestEnum { OK, ERROR, FATAL };
+            };
+            struct TestMessage {
+              TestMessage_Enums::TestEnum error;
+            };
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types[-1],
+            MessageDefinition(
+                name="test_interfaces/msg/TestMessage",
+                definitions=[
+                    MessageDefinitionField(
+                        type="uint32",
+                        name="error",
+                        enumType=("test_interfaces/msg/" "TestMessage_Enums/TestEnum"),
+                    )
+                ],
+            ),
+        )
+
     def test_typedef_resolution(self):
         schema = """
         typedef long MyLong;


### PR DESCRIPTION
## Summary
- resolve partially scoped type names including enums in IDL parser
- support multiline string literals in IDL grammar
- add regression test for nested enum fields with generic test names

## Testing
- `pre-commit run --files python_omgidl/tests/test_parse_ros2idl.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897341c58fc83308d7756b3184bfd1e