### PR TITLE
Normalize boolean type to bool in Python parser

### DIFF
--- a/python_omgidl/omgidl_parser/parse.py
+++ b/python_omgidl/omgidl_parser/parse.py
@@ -184,6 +184,7 @@ class _Transformer(Transformer):
         "unsigned long": "uint32",
         "long long": "int64",
         "long": "int32",
+        "boolean": "bool",
     }
 
     _BUILTIN_TYPES = {
@@ -203,7 +204,7 @@ class _Transformer(Transformer):
         "char",
         "string",
         "wstring",
-        "boolean",
+        "bool",
     }
 
     def __init__(self):

--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -396,11 +396,11 @@ line3")
             result,
             [
                 Constant(name="PI", type="float32", value=3.14),
-                Constant(name="FLAG", type="boolean", value=True),
+                Constant(name="FLAG", type="bool", value=True),
                 Constant(name="GREETING", type="string", value="hello"),
                 Constant(name="GREETING2", type="string", value="hello"),
                 Constant(name="PI2", type="float32", value=3.14),
-                Constant(name="FLAG2", type="boolean", value=True),
+                Constant(name="FLAG2", type="bool", value=True),
             ],
         )
 


### PR DESCRIPTION
## Summary
- normalize `boolean` to `bool` in Python parser and builtin type set
- adjust tests to expect `bool`

## Testing
- `pre-commit run --files python_omgidl/omgidl_parser/parse.py python_omgidl/tests/test_parse.py`
- `pytest python_omgidl/tests`
- `yarn install`
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68973b6343c88330a78b0a2ffebf5dc4