### PR TITLE
feat: support unions in ROS2 IDL parser

### DIFF
--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -80,30 +80,28 @@ def _process_definition(
             MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields)
         )
     elif isinstance(defn, IDLModule):
+        module_scope = [*scope, defn.name]
         const_fields = [
-            _convert_constant(c, typedefs, [*scope, defn.name], idl_map)
+            _convert_constant(c, typedefs, module_scope, idl_map)
             for c in defn.definitions
             if isinstance(c, IDLConstant)
         ]
         if const_fields:
             results.append(
-                MessageDefinition(
-                    name="/".join([*scope, defn.name]), definitions=const_fields
-                )
+                MessageDefinition(name="/".join(module_scope), definitions=const_fields)
             )
         for sub in defn.definitions:
             if isinstance(sub, (IDLModule, IDLStruct, IDLUnion, IDLEnum)):
                 results.extend(
-                    _process_definition(sub, [*scope, defn.name], typedefs, idl_map)
+                    _process_definition(sub, module_scope, typedefs, idl_map)
                 )
     elif isinstance(defn, IDLEnum):
+        enum_scope = [*scope, defn.name]
         fields = [
-            _convert_constant(e, typedefs, [*scope, defn.name], idl_map)
+            _convert_constant(e, typedefs, enum_scope, idl_map)
             for e in defn.enumerators
         ]
-        results.append(
-            MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields)
-        )
+        results.append(MessageDefinition(name="/".join(enum_scope), definitions=fields))
     elif isinstance(defn, IDLConstant):
         results.append(
             MessageDefinition(

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -124,12 +124,11 @@ def _convert_field(
     idl_map: IDLMap,
     scope: List[str],
 ) -> MessageDefinitionField:
-    resolved_type, _ = _resolve_scoped_type(field.type, scope, idl_map)
+    current_type, _ = _resolve_scoped_type(field.type, scope, idl_map)
     array_lengths = list(field.array_lengths)
     is_sequence = field.is_sequence
     seq_bound = field.sequence_bound
     visited: set[str] = set()
-    current_type = resolved_type
     while current_type in typedefs and current_type not in visited:
         visited.add(current_type)
         td = typedefs[current_type]

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -371,6 +371,57 @@ class TestParseRos2idl(unittest.TestCase):
             ],
         )
 
+    def test_union_with_default_case(self):
+        schema = """\
+        module test_msgs {
+          enum ShapeType {
+            SPHERE,
+            BOX
+          };
+          union Shape switch(ShapeType) {
+            case SPHERE: double radius;
+            default: double side;
+          };
+        };
+        """
+        types = parse_ros2idl(schema)
+        self.assertEqual(
+            types,
+            [
+                MessageDefinition(
+                    name="test_msgs/ShapeType",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="uint32",
+                            name="SPHERE",
+                            isConstant=True,
+                            value=0,
+                            valueText="0",
+                        ),
+                        MessageDefinitionField(
+                            type="uint32",
+                            name="BOX",
+                            isConstant=True,
+                            value=1,
+                            valueText="1",
+                        ),
+                    ],
+                ),
+                MessageDefinition(
+                    name="test_msgs/Shape",
+                    definitions=[
+                        MessageDefinitionField(
+                            type="uint32",
+                            name="$discriminator",
+                            enumType="test_msgs/ShapeType",
+                        ),
+                        MessageDefinitionField(type="float64", name="radius"),
+                        MessageDefinitionField(type="float64", name="side"),
+                    ],
+                ),
+            ],
+        )
+
     def test_multi_dimensional_array_not_supported(self):
         schema = """
         struct MultiArray { int32 data[3][5]; };


### PR DESCRIPTION
## Summary
- allow ros2idl parser to generate message definitions for union types
- resolve type references from parent scopes
- add regression test for union handling
- anonymize union test schema names
- extract scoped type resolver to deduplicate scope traversal
- reuse scoped type resolver for constants and typedef chains

## Testing
- `pre-commit run --files python_omgidl/ros2idl_parser/parse.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898cc4f0f2483309d5e7e86bdd770c6