### PR TITLE
Rename message definition package and add helper

### DIFF
--- a/python_omgidl/message_definition/__init__.py
+++ b/python_omgidl/message_definition/__init__.py
@@ -45,9 +45,16 @@ class MessageDefinition:
     definitions: List[MessageDefinitionField] = dataclass_field(default_factory=list)
 
 
+def is_msg_def_equal(a: MessageDefinition, b: MessageDefinition) -> bool:
+    """Return whether two MessageDefinition instances are equal."""
+
+    return a == b
+
+
 __all__ = [
     "ConstantValue",
     "DefaultValue",
     "MessageDefinition",
     "MessageDefinitionField",
+    "is_msg_def_equal",
 ]

--- a/python_omgidl/omgidl_parser/__init__.py
+++ b/python_omgidl/omgidl_parser/__init__.py
@@ -1,4 +1,4 @@
-from foxglove_message_definition import MessageDefinitionField
+from message_definition import MessageDefinitionField
 
 from .parse import (
     Constant,

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
-from foxglove_message_definition import MessageDefinitionField
+from message_definition import MessageDefinitionField
 
 from .parse import Constant, Enum, Field, Module, Struct, Typedef
 from .parse import Union as IDLUnion

--- a/python_omgidl/ros2idl_parser/__init__.py
+++ b/python_omgidl/ros2idl_parser/__init__.py
@@ -1,4 +1,4 @@
-from foxglove_message_definition import MessageDefinition, MessageDefinitionField
+from message_definition import MessageDefinition, MessageDefinitionField
 
 from .parse import parse_ros2idl
 

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import List, Optional, TypeAlias
 
-from foxglove_message_definition import MessageDefinition, MessageDefinitionField
+from message_definition import MessageDefinition, MessageDefinitionField
 from omgidl_parser.parse import Constant as IDLConstant
 from omgidl_parser.parse import Enum as IDLEnum
 from omgidl_parser.parse import Field as IDLField

--- a/python_omgidl/tests/test_message_definition.py
+++ b/python_omgidl/tests/test_message_definition.py
@@ -1,0 +1,23 @@
+from message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+    is_msg_def_equal,
+)
+
+
+def test_is_msg_def_equal() -> None:
+    a = MessageDefinition(
+        name="Foo",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+    b = MessageDefinition(
+        name="Foo",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+    c = MessageDefinition(
+        name="Bar",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+
+    assert is_msg_def_equal(a, b)
+    assert not is_msg_def_equal(a, c)


### PR DESCRIPTION
## Summary
- rename python package to message_definition
- add is_msg_def_equal helper and unit test

## Testing
- `pre-commit run --files python_omgidl/ros2idl_parser/__init__.py python_omgidl/ros2idl_parser/parse.py python_omgidl/omgidl_parser/__init__.py python_omgidl/omgidl_parser/process.py python_omgidl/message_definition/__init__.py python_omgidl/tests/test_message_definition.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998685c8608330b5251d9551958579