### PR TITLE
Handle unions directly in MessageDefinition for ROS 2 IDL

### DIFF
--- a/python_omgidl/message_definition/__init__.py
+++ b/python_omgidl/message_definition/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
+from enum import Enum
 from typing import List, Optional, Sequence, Union
 
 # Type aliases matching the TypeScript package
@@ -38,11 +39,37 @@ class MessageDefinitionField:
 
 
 @dataclass
+class Case:
+    """A single case within a union."""
+
+    predicates: List[Union[int, bool]]
+    type: MessageDefinitionField
+
+
+class AggregatedKind(Enum):
+    MODULE = "module"
+    STRUCT = "struct"
+    UNION = "union"
+
+
+@dataclass
+class UnionDefinition:
+    """A union definition with switch type and cases."""
+
+    switchType: str
+    cases: List[Case]
+    defaultCase: Optional[MessageDefinitionField] = None
+
+
+@dataclass
 class MessageDefinition:
     """A message definition containing an optional name and a list of fields."""
 
     name: Optional[str] = None
-    definitions: List[MessageDefinitionField] = dataclass_field(default_factory=list)
+    aggregatedKind: AggregatedKind = AggregatedKind.STRUCT
+    definitions: Union[List[MessageDefinitionField], UnionDefinition] = dataclass_field(
+        default_factory=list
+    )
 
 
 def is_msg_def_equal(a: MessageDefinition, b: MessageDefinition) -> bool:
@@ -54,6 +81,9 @@ def is_msg_def_equal(a: MessageDefinition, b: MessageDefinition) -> bool:
 __all__ = [
     "ConstantValue",
     "DefaultValue",
+    "Case",
+    "AggregatedKind",
+    "UnionDefinition",
     "MessageDefinition",
     "MessageDefinitionField",
     "is_msg_def_equal",

--- a/python_omgidl/omgidl_parser/process.py
+++ b/python_omgidl/omgidl_parser/process.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
-from message_definition import MessageDefinitionField
+from message_definition import AggregatedKind, Case, MessageDefinitionField
 
 from .parse import Constant, Enum, Field, Module, Struct, Typedef
 from .parse import Union as IDLUnion
@@ -13,16 +13,10 @@ from .parse import Union as IDLUnion
 
 
 @dataclass
-class Case:
-    predicates: List[Union[int, bool]]
-    type: MessageDefinitionField
-
-
-@dataclass
 class IDLStructDefinition:
     name: str
     definitions: List[MessageDefinitionField]
-    aggregatedKind: str = "struct"
+    aggregatedKind: AggregatedKind = AggregatedKind.STRUCT
     annotations: Optional[Dict[str, Any]] = None
 
 
@@ -30,7 +24,7 @@ class IDLStructDefinition:
 class IDLModuleDefinition:
     name: str
     definitions: List[MessageDefinitionField]
-    aggregatedKind: str = "module"
+    aggregatedKind: AggregatedKind = AggregatedKind.MODULE
     annotations: Optional[Dict[str, Any]] = None
 
 
@@ -39,7 +33,7 @@ class IDLUnionDefinition:
     name: str
     switchType: str
     cases: List[Case]
-    aggregatedKind: str = "union"
+    aggregatedKind: AggregatedKind = AggregatedKind.UNION
     defaultCase: Optional[MessageDefinitionField] = None
     annotations: Optional[Dict[str, Any]] = None
 
@@ -188,6 +182,10 @@ def _convert_field(
     array_lengths = list(field.array_lengths)
     if td_arrays:
         array_lengths.extend(td_arrays)
+    if len(array_lengths) > 1:
+        raise ValueError(
+            "Multi-dimensional arrays are not supported in MessageDefinition type"
+        )
     is_sequence = field.is_sequence or td_is_seq
     sequence_bound = field.sequence_bound if field.is_sequence else td_seq_bound
     upper_bound = (

--- a/python_omgidl/ros2idl_parser/__init__.py
+++ b/python_omgidl/ros2idl_parser/__init__.py
@@ -1,5 +1,18 @@
-from message_definition import MessageDefinition, MessageDefinitionField
+from message_definition import (
+    AggregatedKind,
+    Case,
+    MessageDefinition,
+    MessageDefinitionField,
+    UnionDefinition,
+)
 
 from .parse import parse_ros2idl
 
-__all__ = ["parse_ros2idl", "MessageDefinition", "MessageDefinitionField"]
+__all__ = [
+    "parse_ros2idl",
+    "AggregatedKind",
+    "MessageDefinition",
+    "MessageDefinitionField",
+    "UnionDefinition",
+    "Case",
+]

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -29,62 +29,62 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
 
     message_defs: List[MessageDefinition] = []
     for defn in idl_defs:
-        if isinstance(defn, IDLStructDefinition):
-            fields: List[MessageDefinitionField] = []
-            for field in defn.definitions:
-                f = replace(field)
-                f.type = _normalize_name(f.type)
-                if f.enumType:
-                    f.enumType = _normalize_name(f.enumType)
-                fields.append(f)
-            message_defs.append(
-                MessageDefinition(
-                    name=_normalize_name(defn.name),
-                    definitions=fields,
-                    aggregatedKind=AggregatedKind.STRUCT,
+        match defn:
+            case IDLStructDefinition():
+                fields: List[MessageDefinitionField] = []
+                for field in defn.definitions:
+                    f = replace(field)
+                    f.type = _normalize_name(f.type)
+                    if f.enumType:
+                        f.enumType = _normalize_name(f.enumType)
+                    fields.append(f)
+                message_defs.append(
+                    MessageDefinition(
+                        name=_normalize_name(defn.name),
+                        definitions=fields,
+                        aggregatedKind=AggregatedKind.STRUCT,
+                    )
                 )
-            )
-        elif isinstance(defn, IDLModuleDefinition):
-            fields = []
-            for field in defn.definitions:
-                f = replace(field)
-                f.type = _normalize_name(f.type)
-                if f.enumType:
-                    f.enumType = _normalize_name(f.enumType)
-                fields.append(f)
-            message_defs.append(
-                MessageDefinition(
-                    name=_normalize_name(defn.name),
-                    definitions=fields,
-                    aggregatedKind=AggregatedKind.MODULE,
+            case IDLModuleDefinition():
+                fields = []
+                for field in defn.definitions:
+                    f = replace(field)
+                    f.type = _normalize_name(f.type)
+                    if f.enumType:
+                        f.enumType = _normalize_name(f.enumType)
+                    fields.append(f)
+                message_defs.append(
+                    MessageDefinition(
+                        name=_normalize_name(defn.name),
+                        definitions=fields,
+                        aggregatedKind=AggregatedKind.MODULE,
+                    )
                 )
-            )
-        elif isinstance(defn, IDLUnionDefinition):
-            cases: List[Case] = []
-            for c in defn.cases:
-                field = replace(c.type)
-                field.type = _normalize_name(field.type)
-                if field.enumType:
-                    field.enumType = _normalize_name(field.enumType)
-                cases.append(Case(predicates=c.predicates, type=field))
-            default_case = None
-            if defn.defaultCase is not None:
-                default_case = replace(defn.defaultCase)
-                default_case.type = _normalize_name(default_case.type)
-                if default_case.enumType:
-                    default_case.enumType = _normalize_name(default_case.enumType)
-            message_defs.append(
-                MessageDefinition(
-                    name=_normalize_name(defn.name),
-                    aggregatedKind=AggregatedKind.UNION,
-                    definitions=UnionDefinition(
-                        switchType=_normalize_name(defn.switchType),
-                        cases=cases,
-                        defaultCase=default_case,
-                    ),
+            case IDLUnionDefinition():
+                cases: List[Case] = []
+                for c in defn.cases:
+                    field = replace(c.type)
+                    field.type = _normalize_name(field.type)
+                    if field.enumType:
+                        field.enumType = _normalize_name(field.enumType)
+                    cases.append(Case(predicates=c.predicates, type=field))
+                default_case = None
+                if defn.defaultCase is not None:
+                    default_case = replace(defn.defaultCase)
+                    default_case.type = _normalize_name(default_case.type)
+                    if default_case.enumType:
+                        default_case.enumType = _normalize_name(default_case.enumType)
+                message_defs.append(
+                    MessageDefinition(
+                        name=_normalize_name(defn.name),
+                        aggregatedKind=AggregatedKind.UNION,
+                        definitions=UnionDefinition(
+                            switchType=_normalize_name(defn.switchType),
+                            cases=cases,
+                            defaultCase=default_case,
+                        ),
+                    )
                 )
-            )
-
     for msg in message_defs:
         if msg.name in (
             "builtin_interfaces/msg/Time",

--- a/python_omgidl/ros2idl_parser/parse.py
+++ b/python_omgidl/ros2idl_parser/parse.py
@@ -1,52 +1,95 @@
 from __future__ import annotations
 
 import re
-from typing import List, Optional, TypeAlias
+from dataclasses import replace
+from typing import List
 
-from message_definition import MessageDefinition, MessageDefinitionField
-from omgidl_parser.parse import Constant as IDLConstant
-from omgidl_parser.parse import Enum as IDLEnum
-from omgidl_parser.parse import Field as IDLField
-from omgidl_parser.parse import Module as IDLModule
-from omgidl_parser.parse import Struct as IDLStruct
-from omgidl_parser.parse import Typedef as IDLTypedef
-from omgidl_parser.parse import Union as IDLUnion
-from omgidl_parser.parse import parse_idl
-from omgidl_parser.process import build_map
-
-IDLDefinition: TypeAlias = (
-    IDLStruct | IDLModule | IDLConstant | IDLEnum | IDLUnion | IDLTypedef
+from message_definition import (
+    AggregatedKind,
+    Case,
+    MessageDefinition,
+    MessageDefinitionField,
+    UnionDefinition,
 )
-IDLMap: TypeAlias = dict[str, IDLDefinition]
-
-# Field name used for union discriminators in generated message definitions
-UNION_DISCRIMINATOR_PROPERTY_KEY = "$discriminator"
+from omgidl_parser.process import (
+    IDLModuleDefinition,
+    IDLStructDefinition,
+    IDLUnionDefinition,
+    parse_idl_message_definitions,
+)
 
 ROS2IDL_HEADER = re.compile(r"={80}\nIDL: [a-zA-Z][\w]*(?:\/[a-zA-Z][\w]*)*")
 
 
 def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
     """Parse ros2idl schema into message definitions."""
+
     idl_conformed = ROS2IDL_HEADER.sub("", message_definition)
-    parsed = parse_idl(idl_conformed)
-    typedefs = _collect_typedefs(parsed, [])
-    idl_map = build_map(parsed)
+    idl_defs = parse_idl_message_definitions(idl_conformed)
+
     message_defs: List[MessageDefinition] = []
-    for definition in parsed:
-        message_defs.extend(_process_definition(definition, [], typedefs, idl_map))
+    for defn in idl_defs:
+        if isinstance(defn, IDLStructDefinition):
+            fields: List[MessageDefinitionField] = []
+            for field in defn.definitions:
+                f = replace(field)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                fields.append(f)
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    definitions=fields,
+                    aggregatedKind=AggregatedKind.STRUCT,
+                )
+            )
+        elif isinstance(defn, IDLModuleDefinition):
+            fields = []
+            for field in defn.definitions:
+                f = replace(field)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                fields.append(f)
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    definitions=fields,
+                    aggregatedKind=AggregatedKind.MODULE,
+                )
+            )
+        elif isinstance(defn, IDLUnionDefinition):
+            cases: List[Case] = []
+            for c in defn.cases:
+                field = replace(c.type)
+                field.type = _normalize_name(field.type)
+                if field.enumType:
+                    field.enumType = _normalize_name(field.enumType)
+                cases.append(Case(predicates=c.predicates, type=field))
+            default_case = None
+            if defn.defaultCase is not None:
+                default_case = replace(defn.defaultCase)
+                default_case.type = _normalize_name(default_case.type)
+                if default_case.enumType:
+                    default_case.enumType = _normalize_name(default_case.enumType)
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    aggregatedKind=AggregatedKind.UNION,
+                    definitions=UnionDefinition(
+                        switchType=_normalize_name(defn.switchType),
+                        cases=cases,
+                        defaultCase=default_case,
+                    ),
+                )
+            )
 
     for msg in message_defs:
-        if msg.name is not None:
-            msg.name = _normalize_name(msg.name)
-        for field in msg.definitions:
-            field.type = _normalize_name(field.type)
-            if field.enumType:
-                field.enumType = _normalize_name(field.enumType)
-
         if msg.name in (
             "builtin_interfaces/msg/Time",
             "builtin_interfaces/msg/Duration",
-        ):
+        ) and isinstance(msg.definitions, list):
             for field in msg.definitions:
                 if field.name == "nanosec":
                     field.name = "nsec"
@@ -54,171 +97,15 @@ def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
     return message_defs
 
 
-def _process_definition(
-    defn: IDLDefinition,
-    scope: List[str],
-    typedefs: dict[str, IDLTypedef],
-    idl_map: IDLMap,
-) -> List[MessageDefinition]:
-    results: List[MessageDefinition] = []
-    if isinstance(defn, IDLStruct):
-        fields = [_convert_field(f, typedefs, idl_map, scope) for f in defn.fields]
-        results.append(
-            MessageDefinition(name="/".join([*scope, defn.name]), definitions=fields)
-        )
-    elif isinstance(defn, IDLUnion):
-        union_scope = [*scope, defn.name]
-        fields = [
-            _convert_field(
-                IDLField(name=UNION_DISCRIMINATOR_PROPERTY_KEY, type=defn.switch_type),
-                typedefs,
-                idl_map,
-                scope,
-            )
-        ]
-        fields.extend(
-            _convert_field(c.field, typedefs, idl_map, scope) for c in defn.cases
-        )
-        if defn.default is not None:
-            fields.append(_convert_field(defn.default, typedefs, idl_map, scope))
-        results.append(
-            MessageDefinition(name="/".join(union_scope), definitions=fields)
-        )
-    elif isinstance(defn, IDLModule):
-        module_scope = [*scope, defn.name]
-        const_fields = [
-            _convert_constant(c, typedefs, module_scope, idl_map)
-            for c in defn.definitions
-            if isinstance(c, IDLConstant)
-        ]
-        if const_fields:
-            results.append(
-                MessageDefinition(name="/".join(module_scope), definitions=const_fields)
-            )
-        for sub in defn.definitions:
-            if isinstance(sub, (IDLModule, IDLStruct, IDLUnion, IDLEnum)):
-                results.extend(
-                    _process_definition(sub, module_scope, typedefs, idl_map)
-                )
-    elif isinstance(defn, IDLEnum):
-        enum_scope = [*scope, defn.name]
-        fields = [
-            _convert_constant(e, typedefs, enum_scope, idl_map)
-            for e in defn.enumerators
-        ]
-        results.append(MessageDefinition(name="/".join(enum_scope), definitions=fields))
-    elif isinstance(defn, IDLConstant):
-        results.append(
-            MessageDefinition(
-                name="/".join(scope),
-                definitions=[_convert_constant(defn, typedefs, scope, idl_map)],
-            )
-        )
-    # IDLTypedef does not directly produce MessageDefinitions here
-    return results
-
-
-def _convert_field(
-    field: IDLField,
-    typedefs: dict[str, IDLTypedef],
-    idl_map: IDLMap,
-    scope: List[str],
-) -> MessageDefinitionField:
-    current_type, _ = _resolve_scoped_type(field.type, scope, idl_map)
-    array_lengths = list(field.array_lengths)
-    is_sequence = field.is_sequence
-    seq_bound = field.sequence_bound
-    visited: set[str] = set()
-    while current_type in typedefs and current_type not in visited:
-        visited.add(current_type)
-        td = typedefs[current_type]
-        next_type, _ = _resolve_scoped_type(td.type, scope, idl_map)
-        current_type = next_type
-        if td.array_lengths:
-            array_lengths.extend(td.array_lengths)
-        if td.is_sequence:
-            is_sequence = True
-            if td.sequence_bound is not None:
-                seq_bound = td.sequence_bound
-    if len(array_lengths) > 1:
-        raise ValueError(
-            "Multi-dimensional arrays are not supported in MessageDefinition type"
-        )
-    enum_type: Optional[str] = None
-    is_complex = False
-    final_type, definition = _resolve_scoped_type(current_type, scope, idl_map)
-    if isinstance(definition, IDLEnum):
-        enum_type = _normalize_name(final_type)
-        final_type = "uint32"
-    elif isinstance(definition, (IDLStruct, IDLUnion)):
-        is_complex = True
-    return MessageDefinitionField(
-        type=final_type,
-        name=field.name,
-        isComplex=is_complex,
-        enumType=enum_type,
-        isArray=array_lengths or is_sequence,
-        arrayLength=array_lengths[0] if array_lengths else None,
-        arrayUpperBound=seq_bound if is_sequence else None,
-    )
-
-
-def _convert_constant(
-    const: IDLConstant,
-    typedefs: dict[str, IDLTypedef],
-    scope: List[str],
-    idl_map: IDLMap,
-) -> MessageDefinitionField:
-    t, _ = _resolve_scoped_type(const.type, scope, idl_map)
-    t = _resolve_type(t, typedefs)
-    return MessageDefinitionField(
-        type=t,
-        name=const.name,
-        isConstant=True,
-        value=const.value,
-        valueText=str(const.value),
-    )
-
-
 def _normalize_name(name: str) -> str:
-    return name.replace("::", "/") if "::" in name else name
+    s = str(name)
+    return s.replace("::", "/") if "::" in s else s
 
 
-def _collect_typedefs(
-    defs: List[IDLDefinition], scope: List[str]
-) -> dict[str, IDLTypedef]:
-    typedefs: dict[str, IDLTypedef] = {}
-
-    def collect(ds: List[IDLDefinition], sc: List[str]):
-        for d in ds:
-            if isinstance(d, IDLTypedef):
-                typedefs["::".join([*sc, d.name])] = d
-            elif isinstance(d, IDLModule):
-                collect(d.definitions, [*sc, d.name])
-
-    collect(defs, scope)
-    return typedefs
-
-
-def _resolve_scoped_type(
-    name: str, scope: List[str], idl_map: IDLMap
-) -> tuple[str, IDLDefinition | None]:
-    ref = idl_map.get(name)
-    if ref is not None or "::" in name:
-        return name, ref
-    for i in range(len(scope), -1, -1):
-        scoped = "::".join([*scope[:i], name])
-        ref = idl_map.get(scoped)
-        if ref is not None:
-            return scoped, ref
-    return name, None
-
-
-def _resolve_type(name: str, typedefs: dict[str, IDLTypedef]) -> str:
-    t = name
-    visited: set[str] = set()
-    while t in typedefs and t not in visited:
-        visited.add(t)
-        td = typedefs[t]
-        t = td.type
-    return t
+__all__ = [
+    "parse_ros2idl",
+    "AggregatedKind",
+    "MessageDefinition",
+    "MessageDefinitionField",
+    "UnionDefinition",
+]

--- a/python_omgidl/tests/test_parse_ros2idl.py
+++ b/python_omgidl/tests/test_parse_ros2idl.py
@@ -1,6 +1,13 @@
 import unittest
 
-from ros2idl_parser import MessageDefinition, MessageDefinitionField, parse_ros2idl
+from ros2idl_parser import (
+    AggregatedKind,
+    Case,
+    MessageDefinition,
+    MessageDefinitionField,
+    UnionDefinition,
+    parse_ros2idl,
+)
 
 
 class TestParseRos2idl(unittest.TestCase):
@@ -23,6 +30,7 @@ class TestParseRos2idl(unittest.TestCase):
             [
                 MessageDefinition(
                     name="rosidl_parser/action/MyAction_Goal_Constants",
+                    aggregatedKind=AggregatedKind.MODULE,
                     definitions=[
                         MessageDefinitionField(
                             type="int16",
@@ -216,6 +224,7 @@ class TestParseRos2idl(unittest.TestCase):
             [
                 MessageDefinition(
                     name="COLORS",
+                    aggregatedKind=AggregatedKind.MODULE,
                     definitions=[
                         MessageDefinitionField(
                             type="uint32",
@@ -267,6 +276,7 @@ class TestParseRos2idl(unittest.TestCase):
             [
                 MessageDefinition(
                     name="colors/Palette",
+                    aggregatedKind=AggregatedKind.MODULE,
                     definitions=[
                         MessageDefinitionField(
                             type="uint32",
@@ -322,6 +332,7 @@ class TestParseRos2idl(unittest.TestCase):
             [
                 MessageDefinition(
                     name="test_msgs/TestDataType",
+                    aggregatedKind=AggregatedKind.MODULE,
                     definitions=[
                         MessageDefinitionField(
                             type="uint32",
@@ -348,21 +359,41 @@ class TestParseRos2idl(unittest.TestCase):
                 ),
                 MessageDefinition(
                     name="test_msgs/TestData",
-                    definitions=[
-                        MessageDefinitionField(
-                            type="uint32",
-                            name="$discriminator",
-                            enumType="test_msgs/TestDataType",
-                        ),
-                        MessageDefinitionField(type="int32", name="as_int"),
-                        MessageDefinitionField(type="string", name="as_string"),
-                        MessageDefinitionField(type="float64", name="as_float"),
-                    ],
+                    aggregatedKind=AggregatedKind.UNION,
+                    definitions=UnionDefinition(
+                        switchType="uint32",
+                        cases=[
+                            Case(
+                                predicates=[0],
+                                type=MessageDefinitionField(
+                                    type="int32",
+                                    name="as_int",
+                                ),
+                            ),
+                            Case(
+                                predicates=[1],
+                                type=MessageDefinitionField(
+                                    type="string",
+                                    name="as_string",
+                                    upperBound=255,
+                                ),
+                            ),
+                            Case(
+                                predicates=[2],
+                                type=MessageDefinitionField(
+                                    type="float64",
+                                    name="as_float",
+                                ),
+                            ),
+                        ],
+                    ),
                 ),
                 MessageDefinition(
                     name="test_msgs/msg/TestMessage",
                     definitions=[
-                        MessageDefinitionField(type="string", name="label"),
+                        MessageDefinitionField(
+                            type="string", name="label", upperBound=64
+                        ),
                         MessageDefinitionField(
                             type="test_msgs/TestData", name="data", isComplex=True
                         ),
@@ -390,6 +421,7 @@ class TestParseRos2idl(unittest.TestCase):
             [
                 MessageDefinition(
                     name="test_msgs/ShapeType",
+                    aggregatedKind=AggregatedKind.MODULE,
                     definitions=[
                         MessageDefinitionField(
                             type="uint32",
@@ -409,15 +441,23 @@ class TestParseRos2idl(unittest.TestCase):
                 ),
                 MessageDefinition(
                     name="test_msgs/Shape",
-                    definitions=[
-                        MessageDefinitionField(
-                            type="uint32",
-                            name="$discriminator",
-                            enumType="test_msgs/ShapeType",
+                    aggregatedKind=AggregatedKind.UNION,
+                    definitions=UnionDefinition(
+                        switchType="uint32",
+                        cases=[
+                            Case(
+                                predicates=[0],
+                                type=MessageDefinitionField(
+                                    type="float64",
+                                    name="radius",
+                                ),
+                            )
+                        ],
+                        defaultCase=MessageDefinitionField(
+                            type="float64",
+                            name="side",
                         ),
-                        MessageDefinitionField(type="float64", name="radius"),
-                        MessageDefinitionField(type="float64", name="side"),
-                    ],
+                    ),
                 ),
             ],
         )

--- a/python_omgidl/tests/test_process.py
+++ b/python_omgidl/tests/test_process.py
@@ -1,5 +1,6 @@
 import unittest
 
+from message_definition import AggregatedKind
 from omgidl_parser import (
     IDLModuleDefinition,
     IDLStructDefinition,
@@ -41,7 +42,7 @@ class TestProcess(unittest.TestCase):
 
         inner = by_name["outer::Inner"]
         self.assertIsInstance(inner, IDLStructDefinition)
-        self.assertEqual(inner.aggregatedKind, "struct")
+        self.assertEqual(inner.aggregatedKind, AggregatedKind.STRUCT)
         self.assertEqual(len(inner.definitions), 1)
         self.assertEqual(inner.definitions[0].name, "value")
         self.assertEqual(inner.definitions[0].type, "int32")


### PR DESCRIPTION
## Summary
- add `AggregatedKind` enum and encapsulate union metadata in `UnionDefinition`
- build ROS 2 message definitions with the new union container
- update tests for the enum-based aggregated kind

## Testing
- `pre-commit run --files python_omgidl/message_definition/__init__.py python_omgidl/omgidl_parser/process.py python_omgidl/ros2idl_parser/__init__.py python_omgidl/ros2idl_parser/parse.py python_omgidl/tests/test_parse_ros2idl.py python_omgidl/tests/test_process.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899bf0c87908330838c7dbd494ff51c