### PR TITLE
test: parse nested union structure

### DIFF
--- a/python_omgidl/tests/test_parse.py
+++ b/python_omgidl/tests/test_parse.py
@@ -469,6 +469,90 @@ line3")
             ],
         )
 
+    def test_nested_modules_with_union_field(self):
+        schema = """
+        module test_msgs {
+          enum FooEnum {
+            ENUMERATOR1,
+            ENUMERATOR2
+          };
+
+          union FooUnion switch(FooEnum) {
+          case ENUMERATOR1:
+            int32 int_value;
+          case ENUMERATOR2:
+            string<32> string_value;
+          };
+
+          module msg {
+             @verbatim (language="comment", text=
+             "This is a comment about the Bar message")
+             struct Bar {
+               FooUnion union_value;
+               };
+            };
+          };
+        """
+        result = parse_idl(schema)
+        self.assertEqual(
+            result,
+            [
+                Module(
+                    name="test_msgs",
+                    definitions=[
+                        Enum(
+                            name="FooEnum",
+                            enumerators=[
+                                Constant(name="ENUMERATOR1", type="uint32", value=0),
+                                Constant(name="ENUMERATOR2", type="uint32", value=1),
+                            ],
+                        ),
+                        Union(
+                            name="FooUnion",
+                            switch_type="test_msgs::FooEnum",
+                            cases=[
+                                UnionCase(
+                                    predicates=[0],
+                                    field=Field(name="int_value", type="int32"),
+                                ),
+                                UnionCase(
+                                    predicates=[1],
+                                    field=Field(
+                                        name="string_value",
+                                        type="string",
+                                        string_upper_bound=32,
+                                    ),
+                                ),
+                            ],
+                        ),
+                        Module(
+                            name="msg",
+                            definitions=[
+                                Struct(
+                                    name="Bar",
+                                    fields=[
+                                        Field(
+                                            name="union_value",
+                                            type="test_msgs::FooUnion",
+                                        )
+                                    ],
+                                    annotations={
+                                        "verbatim": {
+                                            "language": "comment",
+                                            "text": (
+                                                "This is a comment about the "
+                                                "Bar message"
+                                            ),
+                                        }
+                                    },
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        )
+
     def test_skip_import_and_include(self):
         schema = """
         import "foo.idl";


### PR DESCRIPTION
## Summary
- move nested-union regression test to Python parser to ensure modules with enums, unions, and verbatim annotations parse correctly
- drop redundant TypeScript test

## Testing
- `pytest python_omgidl/tests/test_parse.py::TestParseIDL::test_nested_modules_with_union_field -vv`
- `pytest python_omgidl/tests/test_parse.py`


------
https://chatgpt.com/codex/tasks/task_e_689a0166cf108330a46832a6ffc6741a